### PR TITLE
Fix: Change to resource path in main

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	appCfg.Logger.Info("recieved event")
+	appCfg.Logger.Info("recieved event", zap.Any("Request", req))
 
 	params := handlers.HandlerParams{
 		AppCfg:       appCfg,


### PR DESCRIPTION
Change to resource path check to allow for paths with {} to be used