### PR TITLE
Fix: Change event map to function

### DIFF
--- a/internal/handlers/receiverHandlers.go
+++ b/internal/handlers/receiverHandlers.go
@@ -68,8 +68,8 @@ func HandleReceiverEvent(ctx context.Context, params HandlerParams) (events.APIG
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
-	newEvent, ok := receiver.NewEventMap[receiverEventRequest.EventName]
-	if !ok {
+	newEvent, err := receiver.EventFromName(receiverEventRequest.EventName)
+	if err != nil {
 		params.AppCfg.Logger.Error("unsupported event name provided", zap.Any(log.EventLogKey, receiverEventRequest.EventName), zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
 	}

--- a/internal/receiver/receiver.go
+++ b/internal/receiver/receiver.go
@@ -25,12 +25,21 @@ type Receiver struct {
 	Weights        []events.WeightEvent        `json:"weights" dynamodbav:"weights"`
 }
 
-var NewEventMap = map[string]events.Event{
-	"bowel_movements": events.NewBowelMovementEvent(),
-	"medications":     events.NewMedicationEvent(),
-	"showers":         events.NewShowerEvent(),
-	"urinations":      events.NewUrinationEvent(),
-	"weights":         events.NewWeightEvent(),
+func EventFromName(eventName string) (events.Event, error) {
+	switch eventName {
+	case "bowel_movements":
+		return events.NewBowelMovementEvent(), nil
+	case "medications":
+		return events.NewMedicationEvent(), nil
+	case "showers":
+		return events.NewShowerEvent(), nil
+	case "urinations":
+		return events.NewUrinationEvent(), nil
+	case "weights":
+		return events.NewWeightEvent(), nil
+	default:
+		return nil, fmt.Errorf("event name %s not supported", eventName)
+	}
 }
 
 func NewReceiver(firstName string, lastName string) *Receiver {


### PR DESCRIPTION
Changing event map to a function since the map was only executed during a cold start lambda, causing all the timestamps to be the same for any warm start.