### PR TITLE
Verify user for get receiver handler

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -27,7 +27,7 @@ func TestGetRegisteredHandler(t *testing.T) {
 		}, nil
 	}
 
-	handlersMap = map[Endpoint]func(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error){
+	handlersMap = map[Endpoint]HandlerFunc{
 		{Path: "/testPathOne", Method: "POST"}:   handlerOne,
 		{Path: "/test/path/two", Method: "GET"}:  handlerTwo,
 		{Path: "/test/path/two", Method: "POST"}: handlerThree,

--- a/internal/handlers/receiver.go
+++ b/internal/handlers/receiver.go
@@ -5,26 +5,49 @@ import (
 	"net/http"
 
 	awsevents "github.com/aws/aws-lambda-go/events"
+	"github.com/care-giver-app/care-giver-api/internal/log"
 	"github.com/care-giver-app/care-giver-api/internal/receiver"
 	"github.com/care-giver-app/care-giver-api/internal/response"
+	"github.com/care-giver-app/care-giver-api/internal/user"
 	"go.uber.org/zap"
 )
 
+const (
+	getReceiver = "get receiver"
+)
+
 func HandleReceiver(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
-	params.AppCfg.Logger.Info("handling get receiver event")
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, getReceiver)
 
 	rid, err := validatePathParameters(params.Request, receiver.ParamID, receiver.DBPrefix)
 	if err != nil {
-		params.AppCfg.Logger.Error("error validating path parameters", zap.Error(err))
+		params.AppCfg.Logger.Error(pathParametersError, zap.String(log.ParamIDLogKey, receiver.ParamID), zap.Any(log.PathParametersLogKey, params.Request.PathParameters), zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
+	}
+
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.String(log.ParamIDLogKey, user.ParamID), zap.Any(log.QueryParametersLogKey, params.Request.QueryStringParameters), zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	u, err := params.UserRepo.GetUser(uid)
+	if err != nil {
+		params.AppCfg.Logger.Error(userDatbaseError, zap.String(log.UserIDLogKey, uid), zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+
+	if !u.IsACareGiver(rid) {
+		params.AppCfg.Logger.Error(userNotCareGiverError, zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateAccessDeniedResponse(), nil
 	}
 
 	r, err := params.ReceiverRepo.GetReceiver(rid)
 	if err != nil {
-		params.AppCfg.Logger.Error("error retrieving receiver from db", zap.Error(err))
+		params.AppCfg.Logger.Error(receiverDatabaseError, zap.String(log.ReceiverIDLogKey, rid), zap.Error(err))
 		return response.CreateInternalServerErrorResponse(), nil
 	}
 
-	params.AppCfg.Logger.Info("processed get receiver event successfully")
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, getReceiver)
 	return response.FormatResponse(r, http.StatusOK), nil
 }

--- a/internal/handlers/receiver_test.go
+++ b/internal/handlers/receiver_test.go
@@ -23,22 +23,31 @@ func TestHandleReceiver(t *testing.T) {
 				PathParameters: map[string]string{
 					"receiverId": "Receiver#123",
 				},
+				QueryStringParameters: map[string]string{
+					"userId": "User#123",
+				},
 			},
 			expectedResponse: response.FormatResponse(receiver.Receiver{
 				FirstName: "Success",
 			}, http.StatusOK),
-		},
-		"Sad Path - Wrong Method": {
-			request: events.APIGatewayProxyRequest{
-				HTTPMethod: "BadMethod",
-			},
-			expectedResponse: response.CreateBadRequestResponse(),
 		},
 		"Sad Path - Bad Path Parameters": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod: http.MethodGet,
 				PathParameters: map[string]string{
 					"receiverId": "BadValue",
+				},
+				QueryStringParameters: map[string]string{
+					"userId": "User#123",
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Bad Query Parameters": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				PathParameters: map[string]string{
+					"receiverId": "Receiver#123",
 				},
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
@@ -49,8 +58,35 @@ func TestHandleReceiver(t *testing.T) {
 				PathParameters: map[string]string{
 					"receiverId": "Receiver#Error",
 				},
+				QueryStringParameters: map[string]string{
+					"userId": "User#123",
+				},
 			},
 			expectedResponse: response.CreateInternalServerErrorResponse(),
+		},
+		"Sad Path - Error Getting User From DB": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				PathParameters: map[string]string{
+					"receiverId": "Receiver#123",
+				},
+				QueryStringParameters: map[string]string{
+					"userId": "User#Error",
+				},
+			},
+			expectedResponse: response.CreateInternalServerErrorResponse(),
+		},
+		"Sad Path - User Is Not A Care Giver": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				PathParameters: map[string]string{
+					"receiverId": "Receiver#123",
+				},
+				QueryStringParameters: map[string]string{
+					"userId": "User#NotACareGiver",
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
 	}
 	for name, tc := range tests {

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -13,6 +13,13 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	createUser            = "create user"
+	getUser               = "get user"
+	addPrimaryReceiver    = "add primary receiver"
+	addAdditionalReceiver = "add additional receiver"
+)
+
 type CreateUserRequest struct {
 	Email     string `json:"email" validate:"required"`
 	FirstName string `json:"firstName" validate:"required"`
@@ -41,12 +48,12 @@ type AdditionalReceiverRequest struct {
 }
 
 func HandleCreateUser(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
-	params.AppCfg.Logger.Info("handling create user event")
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, createUser)
 
 	var createUserRequest CreateUserRequest
 	err := readRequestBody(params.Request.Body, &createUserRequest)
 	if err != nil {
-		params.AppCfg.Logger.Error("error reading request body", zap.Error(err))
+		params.AppCfg.Logger.Error(requestBodyError, zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
 	}
 
@@ -64,40 +71,40 @@ func HandleCreateUser(ctx context.Context, params HandlerParams) (events.APIGate
 	}
 
 	resp := CreateUserResponse{
-		UserID: string(user.UserID),
+		UserID: user.UserID,
 		Status: response.Success,
 	}
 
-	params.AppCfg.Logger.Info("processed create user event successfully")
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, createUser)
 	return response.FormatResponse(resp, http.StatusOK), nil
 }
 
 func HandleGetUser(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
-	params.AppCfg.Logger.Info("handling get user event")
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, getUser)
 
 	uid, err := validatePathParameters(params.Request, user.ParamID, user.DBPrefix)
 	if err != nil {
-		params.AppCfg.Logger.Error("error validating path parameters", zap.Error(err))
+		params.AppCfg.Logger.Error(pathParametersError, zap.String(log.ParamIDLogKey, user.ParamID), zap.Any(log.PathParametersLogKey, params.Request.PathParameters), zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
 	}
 
 	u, err := params.UserRepo.GetUser(uid)
 	if err != nil {
-		params.AppCfg.Logger.Error("error retrieving user from db", zap.Error(err))
+		params.AppCfg.Logger.Error(userDatbaseError, zap.String(log.UserIDLogKey, uid), zap.Error(err))
 		return response.CreateInternalServerErrorResponse(), nil
 	}
 
-	params.AppCfg.Logger.Info("processed get user event successfully")
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, getUser)
 	return response.FormatResponse(u, http.StatusOK), nil
 }
 
 func HandleUserPrimaryReceiver(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
-	params.AppCfg.Logger.Info("handling add primary receiver event")
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, addPrimaryReceiver)
 
 	var primaryReceiverRequest PrimaryReceiverRequest
 	err := readRequestBody(params.Request.Body, &primaryReceiverRequest)
 	if err != nil {
-		params.AppCfg.Logger.Error("error reading request body", zap.Error(err))
+		params.AppCfg.Logger.Error(requestBodyError, zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
 	}
 
@@ -122,17 +129,17 @@ func HandleUserPrimaryReceiver(ctx context.Context, params HandlerParams) (event
 		Status:     response.Success,
 	}
 
-	params.AppCfg.Logger.Info("processed add primary receiver event successfully")
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, addPrimaryReceiver)
 	return response.FormatResponse(resp, http.StatusOK), nil
 }
 
 func HandleUserAdditionalReceiver(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
-	params.AppCfg.Logger.Info("handling add additional receiver event")
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, addAdditionalReceiver)
 
 	var additionalReceiverRequest AdditionalReceiverRequest
 	err := readRequestBody(params.Request.Body, &additionalReceiverRequest)
 	if err != nil {
-		params.AppCfg.Logger.Error("error reading request body", zap.Error(err))
+		params.AppCfg.Logger.Error(requestBodyError, zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
 	}
 
@@ -142,7 +149,7 @@ func HandleUserAdditionalReceiver(ctx context.Context, params HandlerParams) (ev
 		return response.CreateInternalServerErrorResponse(), nil
 	}
 
-	params.AppCfg.Logger.Info("processed add additional receiver event successfully")
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, addAdditionalReceiver)
 	return response.FormatResponse(map[string]string{
 		"status": response.Success,
 	}, http.StatusOK), nil

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -20,15 +20,17 @@ var (
 		PanicLevel: zap.PanicLevel,
 	}
 
-	EnvLogKey        = "env"
-	TableNameLogKey  = "table name"
-	UserIDLogKey     = "user id"
-	ReceiverIDLogKey = "receiver id"
-	EventIDLogKey    = "event id"
-	EventLogKey      = "event name"
-	PathLogKey       = "path"
-	MethodLogKey     = "method"
-	ParamIDLogKey    = "param id"
+	EnvLogKey             = "env"
+	TableNameLogKey       = "table name"
+	UserIDLogKey          = "user id"
+	ReceiverIDLogKey      = "receiver id"
+	EventIDLogKey         = "event id"
+	EventLogKey           = "event name"
+	PathLogKey            = "path"
+	QueryParametersLogKey = "query parameters"
+	PathParametersLogKey  = "path parameters"
+	MethodLogKey          = "method"
+	ParamIDLogKey         = "param id"
 )
 
 func GetLogger(level string) (*zap.Logger, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 
 type MockRegistry struct{}
 
-func (m *MockRegistry) GetHandler(request events.APIGatewayProxyRequest) (func(ctx context.Context, params handlers.HandlerParams) (events.APIGatewayProxyResponse, error), bool) {
+func (m *MockRegistry) GetHandler(request events.APIGatewayProxyRequest) (handlers.HandlerFunc, bool) {
 	if request.RequestContext.ResourcePath == "/good/path" {
 		return func(ctx context.Context, params handlers.HandlerParams) (events.APIGatewayProxyResponse, error) {
 			return events.APIGatewayProxyResponse{
@@ -24,7 +24,7 @@ func (m *MockRegistry) GetHandler(request events.APIGatewayProxyRequest) (func(c
 	return nil, false
 }
 
-func (m *MockRegistry) RunHandler(ctx context.Context, handler func(ctx context.Context, params handlers.HandlerParams) (events.APIGatewayProxyResponse, error), request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+func (m *MockRegistry) RunHandler(ctx context.Context, handler handlers.HandlerFunc, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	if handler != nil {
 		params := handlers.HandlerParams{
 			Request: request,

--- a/template.yaml
+++ b/template.yaml
@@ -123,6 +123,9 @@ Resources:
             RestApiId: !Ref CareGiverAPI
             Path: /receiver/{receiverId}
             Method: GET
+            RequestParameters:
+              - method.request.querystring.userId:
+                  Required: true
         AddReceiverEvent:
           Type: Api
           Properties:


### PR DESCRIPTION
This PR enforces the user id as a query param for getting the receiver. This is to note share any receiver data with unauthorized users