### PR TITLE
feat: add OpenAPI spec with swaggo/swag annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,11 @@ jobs:
 
         - name: Run Unit Tests
           run: go test -short -coverprofile cover.out ./...
+
+        - name: Install swag
+          run: go install github.com/swaggo/swag/cmd/swag@latest
+
+        - name: Verify swagger spec is up to date
+          run: |
+            swag init -g main.go -o docs --outputTypes json,yaml --parseDependency
+            git diff --exit-code docs/

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,14 @@ test:
 test-report: test
 	go tool cover -html=cover.out
 
-lint: 
+lint:
 	golangci-lint run
+
+swagger:
+	go run github.com/swaggo/swag/cmd/swag@latest init -g main.go -o docs --outputTypes json,yaml --parseDependency
+
+swagger-ui:
+	docker run --rm -p 8080:8080 \
+	  -e SWAGGER_JSON=/spec/swagger.json \
+	  -v $(PWD)/docs:/spec \
+	  swaggerapi/swagger-ui

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,0 +1,7 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "contact": {}
+    },
+    "paths": {}
+}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8,7 +8,375 @@
     },
     "host": "api.caretosher.com",
     "basePath": "/",
-    "paths": {},
+    "paths": {
+        "/user": {
+            "post": {
+                "tags": [
+                    "users"
+                ],
+                "summary": "Create a new user account",
+                "parameters": [
+                    {
+                        "description": "User details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateUserResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/user/additional-receiver": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Add an additional caregiver to an existing receiver (requester must be the primary caregiver)",
+                "parameters": [
+                    {
+                        "description": "User ID, receiver ID, and email of the caregiver to add",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.AdditionalReceiverRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/user/primary-receiver": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Add a primary receiver for a user (creates the receiver and a primary caregiver relationship)",
+                "parameters": [
+                    {
+                        "description": "User and receiver details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.PrimaryReceiverRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.PrimaryReceiverResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/user/relationships/{userId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get all receiver relationships for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID (format: User#\u003cuuid\u003e)",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GetUserRelationshipsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/user/{userId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get a user by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID (format: User#\u003cuuid\u003e)",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/user.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "handlers.AdditionalReceiverRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "receiverId",
+                "userId"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "receiverId": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CreateUserRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "firstName",
+                "lastName"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CreateUserResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GetUserRelationshipsResponse": {
+            "type": "object",
+            "properties": {
+                "relationships": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/relationship.Relationship"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.PrimaryReceiverRequest": {
+            "type": "object",
+            "required": [
+                "firstName",
+                "lastName",
+                "userId"
+            ],
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.PrimaryReceiverResponse": {
+            "type": "object",
+            "properties": {
+                "receiverId": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "relationship.Relationship": {
+            "type": "object",
+            "properties": {
+                "emailNotifications": {
+                    "type": "boolean"
+                },
+                "primaryCareGiver": {
+                    "type": "boolean"
+                },
+                "receiverId": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "user.User": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        }
+    },
     "securityDefinitions": {
         "BearerAuth": {
             "type": "apiKey",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,7 +1,19 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "REST API for the CareToSher care-giving collaboration platform. All routes require a Cognito JWT except POST /user.",
+        "title": "CareToSher API",
+        "contact": {},
+        "version": "1.0"
     },
-    "paths": {}
+    "host": "api.caretosher.com",
+    "basePath": "/",
+    "paths": {},
+    "securityDefinitions": {
+        "BearerAuth": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
+    }
 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -224,6 +224,56 @@
                 }
             }
         },
+        "/feedback": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "feedback"
+                ],
+                "summary": "Submit user feedback (enqueues a notification via SQS)",
+                "parameters": [
+                    {
+                        "description": "Feedback message",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.FeedbackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.FeedbackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/receiver/care-givers/{receiverId}": {
             "get": {
                 "security": [
@@ -801,6 +851,25 @@
                     "type": "string"
                 },
                 "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.FeedbackRequest": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.FeedbackResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9,6 +9,221 @@
     "host": "api.caretosher.com",
     "basePath": "/",
     "paths": {
+        "/event": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "events"
+                ],
+                "summary": "Create a care event for a receiver",
+                "parameters": [
+                    {
+                        "description": "Event details. startTime and endTime must be RFC3339. type must match a valid event config.",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ReceiverEventRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ReceiverEventResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/event/{eventId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "events"
+                ],
+                "summary": "Delete a care event",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Event ID (format: Event#\u003cuuid\u003e)",
+                        "name": "eventId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Receiver ID (format: Receiver#\u003cuuid\u003e)",
+                        "name": "receiverId",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "ID of the requesting user (format: User#\u003cuuid\u003e)",
+                        "name": "userId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/events/configs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "events"
+                ],
+                "summary": "Get all available event type configurations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/event.EventConfig"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/events/{receiverId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "events"
+                ],
+                "summary": "Get all care events for a receiver",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Receiver ID (format: Receiver#\u003cuuid\u003e)",
+                        "name": "receiverId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "ID of the requesting user (format: User#\u003cuuid\u003e)",
+                        "name": "userId",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start of time range (RFC3339). Must be provided with endTime.",
+                        "name": "startTime",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of time range (RFC3339). Must be provided with startTime.",
+                        "name": "endTime",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/event.Entry"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/receiver/care-givers/{receiverId}": {
             "get": {
                 "security": [
@@ -359,6 +574,171 @@
         }
     },
     "definitions": {
+        "event.AlertThresholds": {
+            "type": "object",
+            "properties": {
+                "critical": {
+                    "type": "integer"
+                },
+                "red": {
+                    "type": "integer"
+                },
+                "yellow": {
+                    "type": "integer"
+                }
+            }
+        },
+        "event.ColorConfig": {
+            "type": "object",
+            "properties": {
+                "primary": {
+                    "type": "string"
+                },
+                "secondary": {
+                    "type": "string"
+                }
+            }
+        },
+        "event.DataConfig": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "unit": {
+                    "type": "string"
+                }
+            }
+        },
+        "event.DataPoint": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "event.Entry": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/event.DataPoint"
+                    }
+                },
+                "endTime": {
+                    "type": "string"
+                },
+                "eventId": {
+                    "type": "string"
+                },
+                "note": {
+                    "type": "string"
+                },
+                "receiverId": {
+                    "type": "string"
+                },
+                "startTime": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "event.EventConfig": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "$ref": "#/definitions/event.ColorConfig"
+                },
+                "data": {
+                    "$ref": "#/definitions/event.DataConfig"
+                },
+                "fields": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/event.FieldConfig"
+                    }
+                },
+                "graph": {
+                    "$ref": "#/definitions/event.GraphConfig"
+                },
+                "hasQuickAdd": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "monitor": {
+                    "$ref": "#/definitions/event.MonitorConfig"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "upcoming": {
+                    "$ref": "#/definitions/event.UpcomingConfig"
+                }
+            }
+        },
+        "event.FieldConfig": {
+            "type": "object",
+            "properties": {
+                "inputType": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "placeholder": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "event.GraphConfig": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "event.MonitorConfig": {
+            "type": "object",
+            "properties": {
+                "alertThresholds": {
+                    "$ref": "#/definitions/event.AlertThresholds"
+                },
+                "showLastValue": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "event.UpcomingConfig": {
+            "type": "object",
+            "properties": {
+                "lookAheadDays": {
+                    "type": "integer"
+                },
+                "show": {
+                    "type": "boolean"
+                }
+            }
+        },
         "handlers.AdditionalReceiverRequest": {
             "type": "object",
             "required": [
@@ -472,6 +852,56 @@
         "handlers.PrimaryReceiverResponse": {
             "type": "object",
             "properties": {
+                "receiverId": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ReceiverEventRequest": {
+            "type": "object",
+            "required": [
+                "endTime",
+                "receiverId",
+                "startTime",
+                "type",
+                "userId"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/event.DataPoint"
+                    }
+                },
+                "endTime": {
+                    "type": "string"
+                },
+                "note": {
+                    "type": "string"
+                },
+                "receiverId": {
+                    "type": "string"
+                },
+                "startTime": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ReceiverEventResponse": {
+            "type": "object",
+            "properties": {
+                "eventId": {
+                    "type": "string"
+                },
                 "receiverId": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9,6 +9,116 @@
     "host": "api.caretosher.com",
     "basePath": "/",
     "paths": {
+        "/receiver/care-givers/{receiverId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "receivers"
+                ],
+                "summary": "Get all caregivers for a receiver",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Receiver ID (format: Receiver#\u003cuuid\u003e)",
+                        "name": "receiverId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "ID of the requesting user (format: User#\u003cuuid\u003e)",
+                        "name": "userId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GetReceiverCareGiversResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/receiver/{receiverId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "receivers"
+                ],
+                "summary": "Get a receiver by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Receiver ID (format: Receiver#\u003cuuid\u003e)",
+                        "name": "receiverId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "ID of the requesting user (format: User#\u003cuuid\u003e)",
+                        "name": "userId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/receiver.Receiver"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Access denied",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "post": {
                 "tags": [
@@ -268,6 +378,23 @@
                 }
             }
         },
+        "handlers.CareGiverResponse": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "isPrimary": {
+                    "type": "boolean"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.CreateUserRequest": {
             "type": "object",
             "required": [
@@ -295,6 +422,17 @@
                 },
                 "userId": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.GetReceiverCareGiversResponse": {
+            "type": "object",
+            "properties": {
+                "careGivers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.CareGiverResponse"
+                    }
                 }
             }
         },
@@ -338,6 +476,20 @@
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "receiver.Receiver": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "receiverId": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,4 @@
+info:
+  contact: {}
+paths: {}
+swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,89 @@
 basePath: /
+definitions:
+  handlers.AdditionalReceiverRequest:
+    properties:
+      email:
+        type: string
+      receiverId:
+        type: string
+      userId:
+        type: string
+    required:
+    - email
+    - receiverId
+    - userId
+    type: object
+  handlers.CreateUserRequest:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+    required:
+    - email
+    - firstName
+    - lastName
+    type: object
+  handlers.CreateUserResponse:
+    properties:
+      status:
+        type: string
+      userId:
+        type: string
+    type: object
+  handlers.GetUserRelationshipsResponse:
+    properties:
+      relationships:
+        items:
+          $ref: '#/definitions/relationship.Relationship'
+        type: array
+      status:
+        type: string
+    type: object
+  handlers.PrimaryReceiverRequest:
+    properties:
+      firstName:
+        type: string
+      lastName:
+        type: string
+      userId:
+        type: string
+    required:
+    - firstName
+    - lastName
+    - userId
+    type: object
+  handlers.PrimaryReceiverResponse:
+    properties:
+      receiverId:
+        type: string
+      status:
+        type: string
+    type: object
+  relationship.Relationship:
+    properties:
+      emailNotifications:
+        type: boolean
+      primaryCareGiver:
+        type: boolean
+      receiverId:
+        type: string
+      userId:
+        type: string
+    type: object
+  user.User:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      userId:
+        type: string
+    type: object
 host: api.caretosher.com
 info:
   contact: {}
@@ -6,7 +91,158 @@ info:
     routes require a Cognito JWT except POST /user.
   title: CareToSher API
   version: "1.0"
-paths: {}
+paths:
+  /user:
+    post:
+      parameters:
+      - description: User details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CreateUserRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.CreateUserResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Create a new user account
+      tags:
+      - users
+  /user/{userId}:
+    get:
+      parameters:
+      - description: 'User ID (format: User#<uuid>)'
+        in: path
+        name: userId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/user.User'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get a user by ID
+      tags:
+      - users
+  /user/additional-receiver:
+    post:
+      parameters:
+      - description: User ID, receiver ID, and email of the caregiver to add
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.AdditionalReceiverRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Add an additional caregiver to an existing receiver (requester must
+        be the primary caregiver)
+      tags:
+      - users
+  /user/primary-receiver:
+    post:
+      parameters:
+      - description: User and receiver details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.PrimaryReceiverRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.PrimaryReceiverResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Add a primary receiver for a user (creates the receiver and a primary
+        caregiver relationship)
+      tags:
+      - users
+  /user/relationships/{userId}:
+    get:
+      parameters:
+      - description: 'User ID (format: User#<uuid>)'
+        in: path
+        name: userId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.GetUserRelationshipsResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get all receiver relationships for a user
+      tags:
+      - users
 securityDefinitions:
   BearerAuth:
     in: header

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,15 @@
+basePath: /
+host: api.caretosher.com
 info:
   contact: {}
+  description: REST API for the CareToSher care-giving collaboration platform. All
+    routes require a Cognito JWT except POST /user.
+  title: CareToSher API
+  version: "1.0"
 paths: {}
+securityDefinitions:
+  BearerAuth:
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -151,6 +151,18 @@ definitions:
       userId:
         type: string
     type: object
+  handlers.FeedbackRequest:
+    properties:
+      message:
+        type: string
+    required:
+    - message
+    type: object
+  handlers.FeedbackResponse:
+    properties:
+      status:
+        type: string
+    type: object
   handlers.GetReceiverCareGiversResponse:
     properties:
       careGivers:
@@ -397,6 +409,37 @@ paths:
       summary: Get all available event type configurations
       tags:
       - events
+  /feedback:
+    post:
+      parameters:
+      - description: Feedback message
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.FeedbackRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.FeedbackResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Submit user feedback (enqueues a notification via SQS)
+      tags:
+      - feedback
   /receiver/{receiverId}:
     get:
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -13,6 +13,17 @@ definitions:
     - receiverId
     - userId
     type: object
+  handlers.CareGiverResponse:
+    properties:
+      firstName:
+        type: string
+      isPrimary:
+        type: boolean
+      lastName:
+        type: string
+      userId:
+        type: string
+    type: object
   handlers.CreateUserRequest:
     properties:
       email:
@@ -32,6 +43,13 @@ definitions:
         type: string
       userId:
         type: string
+    type: object
+  handlers.GetReceiverCareGiversResponse:
+    properties:
+      careGivers:
+        items:
+          $ref: '#/definitions/handlers.CareGiverResponse'
+        type: array
     type: object
   handlers.GetUserRelationshipsResponse:
     properties:
@@ -60,6 +78,15 @@ definitions:
       receiverId:
         type: string
       status:
+        type: string
+    type: object
+  receiver.Receiver:
+    properties:
+      firstName:
+        type: string
+      lastName:
+        type: string
+      receiverId:
         type: string
     type: object
   relationship.Relationship:
@@ -92,6 +119,76 @@ info:
   title: CareToSher API
   version: "1.0"
 paths:
+  /receiver/{receiverId}:
+    get:
+      parameters:
+      - description: 'Receiver ID (format: Receiver#<uuid>)'
+        in: path
+        name: receiverId
+        required: true
+        type: string
+      - description: 'ID of the requesting user (format: User#<uuid>)'
+        in: query
+        name: userId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/receiver.Receiver'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get a receiver by ID
+      tags:
+      - receivers
+  /receiver/care-givers/{receiverId}:
+    get:
+      parameters:
+      - description: 'Receiver ID (format: Receiver#<uuid>)'
+        in: path
+        name: receiverId
+        required: true
+        type: string
+      - description: 'ID of the requesting user (format: User#<uuid>)'
+        in: query
+        name: userId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.GetReceiverCareGiversResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get all caregivers for a receiver
+      tags:
+      - receivers
   /user:
     post:
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,112 @@
 basePath: /
 definitions:
+  event.AlertThresholds:
+    properties:
+      critical:
+        type: integer
+      red:
+        type: integer
+      yellow:
+        type: integer
+    type: object
+  event.ColorConfig:
+    properties:
+      primary:
+        type: string
+      secondary:
+        type: string
+    type: object
+  event.DataConfig:
+    properties:
+      name:
+        type: string
+      unit:
+        type: string
+    type: object
+  event.DataPoint:
+    properties:
+      name:
+        type: string
+      value: {}
+    type: object
+  event.Entry:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/event.DataPoint'
+        type: array
+      endTime:
+        type: string
+      eventId:
+        type: string
+      note:
+        type: string
+      receiverId:
+        type: string
+      startTime:
+        type: string
+      type:
+        type: string
+      userId:
+        type: string
+    type: object
+  event.EventConfig:
+    properties:
+      color:
+        $ref: '#/definitions/event.ColorConfig'
+      data:
+        $ref: '#/definitions/event.DataConfig'
+      fields:
+        items:
+          $ref: '#/definitions/event.FieldConfig'
+        type: array
+      graph:
+        $ref: '#/definitions/event.GraphConfig'
+      hasQuickAdd:
+        type: boolean
+      icon:
+        type: string
+      monitor:
+        $ref: '#/definitions/event.MonitorConfig'
+      type:
+        type: string
+      upcoming:
+        $ref: '#/definitions/event.UpcomingConfig'
+    type: object
+  event.FieldConfig:
+    properties:
+      inputType:
+        type: string
+      label:
+        type: string
+      name:
+        type: string
+      placeholder:
+        type: string
+      required:
+        type: boolean
+    type: object
+  event.GraphConfig:
+    properties:
+      title:
+        type: string
+      type:
+        type: string
+    type: object
+  event.MonitorConfig:
+    properties:
+      alertThresholds:
+        $ref: '#/definitions/event.AlertThresholds'
+      showLastValue:
+        type: boolean
+    type: object
+  event.UpcomingConfig:
+    properties:
+      lookAheadDays:
+        type: integer
+      show:
+        type: boolean
+    type: object
   handlers.AdditionalReceiverRequest:
     properties:
       email:
@@ -80,6 +187,40 @@ definitions:
       status:
         type: string
     type: object
+  handlers.ReceiverEventRequest:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/event.DataPoint'
+        type: array
+      endTime:
+        type: string
+      note:
+        type: string
+      receiverId:
+        type: string
+      startTime:
+        type: string
+      type:
+        type: string
+      userId:
+        type: string
+    required:
+    - endTime
+    - receiverId
+    - startTime
+    - type
+    - userId
+    type: object
+  handlers.ReceiverEventResponse:
+    properties:
+      eventId:
+        type: string
+      receiverId:
+        type: string
+      status:
+        type: string
+    type: object
   receiver.Receiver:
     properties:
       firstName:
@@ -119,6 +260,143 @@ info:
   title: CareToSher API
   version: "1.0"
 paths:
+  /event:
+    post:
+      parameters:
+      - description: Event details. startTime and endTime must be RFC3339. type must
+          match a valid event config.
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.ReceiverEventRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.ReceiverEventResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Create a care event for a receiver
+      tags:
+      - events
+  /event/{eventId}:
+    delete:
+      parameters:
+      - description: 'Event ID (format: Event#<uuid>)'
+        in: path
+        name: eventId
+        required: true
+        type: string
+      - description: 'Receiver ID (format: Receiver#<uuid>)'
+        in: query
+        name: receiverId
+        required: true
+        type: string
+      - description: 'ID of the requesting user (format: User#<uuid>)'
+        in: query
+        name: userId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Delete a care event
+      tags:
+      - events
+  /events/{receiverId}:
+    get:
+      parameters:
+      - description: 'Receiver ID (format: Receiver#<uuid>)'
+        in: path
+        name: receiverId
+        required: true
+        type: string
+      - description: 'ID of the requesting user (format: User#<uuid>)'
+        in: query
+        name: userId
+        required: true
+        type: string
+      - description: Start of time range (RFC3339). Must be provided with endTime.
+        in: query
+        name: startTime
+        type: string
+      - description: End of time range (RFC3339). Must be provided with startTime.
+        in: query
+        name: endTime
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/event.Entry'
+            type: array
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "403":
+          description: Access denied
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get all care events for a receiver
+      tags:
+      - events
+  /events/configs:
+    get:
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/event.EventConfig'
+            type: array
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get all available event type configurations
+      tags:
+      - events
   /receiver/{receiverId}:
     get:
       parameters:

--- a/internal/handlers/event.go
+++ b/internal/handlers/event.go
@@ -38,6 +38,15 @@ type ReceiverEventResponse struct {
 	Status     string `json:"status"`
 }
 
+// @Summary Create a care event for a receiver
+// @Tags events
+// @Security BearerAuth
+// @Param body body ReceiverEventRequest true "Event details. startTime and endTime must be RFC3339. type must match a valid event config."
+// @Success 200 {object} ReceiverEventResponse
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /event [post]
 func HandleReceiverEvent(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, addReceiverEvent)
 	params.AppCfg.Logger.Info("handling add receiver event")
@@ -101,6 +110,17 @@ func HandleReceiverEvent(ctx context.Context, params HandlerParams) (awsevents.A
 	}, http.StatusOK), nil
 }
 
+// @Summary Delete a care event
+// @Tags events
+// @Security BearerAuth
+// @Param eventId path string true "Event ID (format: Event#<uuid>)"
+// @Param receiverId query string true "Receiver ID (format: Receiver#<uuid>)"
+// @Param userId query string true "ID of the requesting user (format: User#<uuid>)"
+// @Success 200 {object} map[string]string
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /event/{eventId} [delete]
 func HandleDeleteReceiverEvent(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, deleteReceiverEvent)
 
@@ -153,6 +173,18 @@ func HandleDeleteReceiverEvent(ctx context.Context, params HandlerParams) (awsev
 	), nil
 }
 
+// @Summary Get all care events for a receiver
+// @Tags events
+// @Security BearerAuth
+// @Param receiverId path string true "Receiver ID (format: Receiver#<uuid>)"
+// @Param userId query string true "ID of the requesting user (format: User#<uuid>)"
+// @Param startTime query string false "Start of time range (RFC3339). Must be provided with endTime."
+// @Param endTime query string false "End of time range (RFC3339). Must be provided with startTime."
+// @Success 200 {object} []event.Entry
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /events/{receiverId} [get]
 func HandleGetReceiverEvents(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getReceiverEvents)
 
@@ -205,6 +237,12 @@ func HandleGetReceiverEvents(ctx context.Context, params HandlerParams) (awseven
 	return response.FormatResponse(eventsList, http.StatusOK), nil
 }
 
+// @Summary Get all available event type configurations
+// @Tags events
+// @Security BearerAuth
+// @Success 200 {object} []event.EventConfig
+// @Failure 500 {string} string "Internal server error"
+// @Router /events/configs [get]
 func HandleGetEventConfigs(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getEventConfigs)
 

--- a/internal/handlers/feedback.go
+++ b/internal/handlers/feedback.go
@@ -35,6 +35,15 @@ type FeedbackNotification struct {
 	Message string `json:"message"`
 }
 
+// @Summary Submit user feedback (enqueues a notification via SQS)
+// @Tags feedback
+// @Security BearerAuth
+// @Param body body FeedbackRequest true "Feedback message"
+// @Success 200 {object} FeedbackResponse
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /feedback [post]
 func HandleFeedbackRequest(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, submitFeedback)
 

--- a/internal/handlers/receiver.go
+++ b/internal/handlers/receiver.go
@@ -18,6 +18,16 @@ const (
 	getReceiverCareGivers = "get receiver care givers"
 )
 
+// @Summary Get a receiver by ID
+// @Tags receivers
+// @Security BearerAuth
+// @Param receiverId path string true "Receiver ID (format: Receiver#<uuid>)"
+// @Param userId query string true "ID of the requesting user (format: User#<uuid>)"
+// @Success 200 {object} receiver.Receiver
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /receiver/{receiverId} [get]
 func HandleReceiver(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getReceiver)
 
@@ -65,6 +75,16 @@ type GetReceiverCareGiversResponse struct {
 	CareGivers []CareGiverResponse `json:"careGivers"`
 }
 
+// @Summary Get all caregivers for a receiver
+// @Tags receivers
+// @Security BearerAuth
+// @Param receiverId path string true "Receiver ID (format: Receiver#<uuid>)"
+// @Param userId query string true "ID of the requesting user (format: User#<uuid>)"
+// @Success 200 {object} GetReceiverCareGiversResponse
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /receiver/care-givers/{receiverId} [get]
 func HandleGetReceiverCareGivers(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getReceiverCareGivers)
 

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -53,6 +53,13 @@ type GetUserRelationshipsResponse struct {
 	Status        string                      `json:"status"`
 }
 
+// @Summary Create a new user account
+// @Tags users
+// @Param body body CreateUserRequest true "User details"
+// @Success 200 {object} CreateUserResponse
+// @Failure 400 {string} string "Bad request"
+// @Failure 500 {string} string "Internal server error"
+// @Router /user [post]
 func HandleCreateUser(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, createUser)
 
@@ -85,6 +92,15 @@ func HandleCreateUser(ctx context.Context, params HandlerParams) (events.APIGate
 	return response.FormatResponse(resp, http.StatusOK), nil
 }
 
+// @Summary Get a user by ID
+// @Tags users
+// @Security BearerAuth
+// @Param userId path string true "User ID (format: User#<uuid>)"
+// @Success 200 {object} user.User
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /user/{userId} [get]
 func HandleGetUser(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getUser)
 
@@ -104,6 +120,15 @@ func HandleGetUser(ctx context.Context, params HandlerParams) (events.APIGateway
 	return response.FormatResponse(u, http.StatusOK), nil
 }
 
+// @Summary Add a primary receiver for a user (creates the receiver and a primary caregiver relationship)
+// @Tags users
+// @Security BearerAuth
+// @Param body body PrimaryReceiverRequest true "User and receiver details"
+// @Success 200 {object} PrimaryReceiverResponse
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /user/primary-receiver [post]
 func HandleUserPrimaryReceiver(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, addPrimaryReceiver)
 
@@ -140,6 +165,15 @@ func HandleUserPrimaryReceiver(ctx context.Context, params HandlerParams) (event
 	return response.FormatResponse(resp, http.StatusOK), nil
 }
 
+// @Summary Add an additional caregiver to an existing receiver (requester must be the primary caregiver)
+// @Tags users
+// @Security BearerAuth
+// @Param body body AdditionalReceiverRequest true "User ID, receiver ID, and email of the caregiver to add"
+// @Success 200 {object} map[string]string
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /user/additional-receiver [post]
 func HandleUserAdditionalReceiver(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, addAdditionalReceiver)
 
@@ -180,6 +214,15 @@ func HandleUserAdditionalReceiver(ctx context.Context, params HandlerParams) (ev
 	}, http.StatusOK), nil
 }
 
+// @Summary Get all receiver relationships for a user
+// @Tags users
+// @Security BearerAuth
+// @Param userId path string true "User ID (format: User#<uuid>)"
+// @Success 200 {object} GetUserRelationshipsResponse
+// @Failure 400 {string} string "Bad request"
+// @Failure 403 {string} string "Access denied"
+// @Failure 500 {string} string "Internal server error"
+// @Router /user/relationships/{userId} [get]
 func HandleGetUserRelationships(ctx context.Context, params HandlerParams) (events.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, "get user relationships")
 

--- a/main.go
+++ b/main.go
@@ -70,6 +70,14 @@ func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 	return response.CreateBadRequestResponse(), nil
 }
 
+// @title CareToSher API
+// @version 1.0
+// @description REST API for the CareToSher care-giving collaboration platform. All routes require a Cognito JWT except POST /user.
+// @host api.caretosher.com
+// @BasePath /
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
 func main() {
 	lambda.Start(handler)
 }


### PR DESCRIPTION
## Summary

- Added swaggo/swag annotations to all 12 handlers across `user.go`, `receiver.go`, `event.go`, and `feedback.go`
- Added API info block and Cognito `BearerAuth` security scheme to `main.go`
- Added `make swagger` target to generate `docs/swagger.yaml` + `docs/swagger.json` from annotations
- Added `make swagger-ui` target to serve an interactive UI via Docker at `http://localhost:8080`
- Added CI step to `build.yml` that regenerates the spec and fails on any diff — prevents the spec from drifting out of sync with the code

## Test Plan

- [ ] Run `make swagger` — confirm `docs/swagger.yaml` and `docs/swagger.json` are generated without errors
- [ ] Open `docs/swagger.yaml` and confirm all 12 routes are present with correct auth, params, and response schemas
- [ ] Optionally run `make swagger-ui` (requires Docker) and verify the rendered UI at `http://localhost:8080`
- [ ] Confirm CI passes on this PR — the swagger verification step should be green
- [ ] Add a comment to any handler and re-run `make swagger` without committing — confirm `git diff --exit-code docs/` exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)