### PR TITLE
Minor: custom tracker CRUD API and template catalog (spec 002)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.53.3
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21
-	github.com/care-giver-app/care-giver-golang-common v0.7.0
+	github.com/care-giver-app/care-giver-golang-common v0.8.0
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.53.3
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21
-	github.com/care-giver-app/care-giver-golang-common v0.6.0
+	github.com/care-giver-app/care-giver-golang-common v0.7.0
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.3 h1:tzMkjh0yTChUqJDgGkcDdxvZDSrJ
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.3/go.mod h1:T270C0R5sZNLbWUe8ueiAF42XSZxxPocTaGSgs5c/60=
 github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
 github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
-github.com/care-giver-app/care-giver-golang-common v0.7.0 h1:oSdVjGCQS5g9ghHY5jP6tvwomIwp6sAPRRp7+UEnxn8=
-github.com/care-giver-app/care-giver-golang-common v0.7.0/go.mod h1:KfypSFU/TS5b9mzTQVOQOX7YDc83CMNOvSdkdNI92Vc=
+github.com/care-giver-app/care-giver-golang-common v0.8.0 h1:L9f5kAYw3RnOJIO5jIkV+e2NBPcIEd/vsQ3WmYBSA8s=
+github.com/care-giver-app/care-giver-golang-common v0.8.0/go.mod h1:KfypSFU/TS5b9mzTQVOQOX7YDc83CMNOvSdkdNI92Vc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.3 h1:tzMkjh0yTChUqJDgGkcDdxvZDSrJ
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.3/go.mod h1:T270C0R5sZNLbWUe8ueiAF42XSZxxPocTaGSgs5c/60=
 github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
 github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
-github.com/care-giver-app/care-giver-golang-common v0.6.0 h1:90j6X9qjO+FlwSdkcZhyu94GSMhbD+iQJ5Z6Go//l/M=
-github.com/care-giver-app/care-giver-golang-common v0.6.0/go.mod h1:KfypSFU/TS5b9mzTQVOQOX7YDc83CMNOvSdkdNI92Vc=
+github.com/care-giver-app/care-giver-golang-common v0.7.0 h1:oSdVjGCQS5g9ghHY5jP6tvwomIwp6sAPRRp7+UEnxn8=
+github.com/care-giver-app/care-giver-golang-common v0.7.0/go.mod h1:KfypSFU/TS5b9mzTQVOQOX7YDc83CMNOvSdkdNI92Vc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=

--- a/internal/appconfig/appconfig.go
+++ b/internal/appconfig/appconfig.go
@@ -22,6 +22,7 @@ type AppConfig struct {
 	EventTableName        string
 	RelationshipTableName string
 	FeedbackQueueURL      string
+	TrackerTableName      string
 }
 
 func NewAppConfig() *AppConfig {
@@ -42,6 +43,7 @@ func (a *AppConfig) ReadEnvVars() {
 	a.EventTableName = getEnvVarStringOrDefault("EVENT_TABLE_NAME", fmt.Sprintf("%s-%s", "event-table", LocalEnv))
 	a.RelationshipTableName = getEnvVarStringOrDefault("RELATIONSHIP_TABLE_NAME", fmt.Sprintf("%s-%s", "relationship-table", LocalEnv))
 	a.FeedbackQueueURL = getEnvVarStringOrDefault("FEEDBACK_QUEUE_URL", "")
+	a.TrackerTableName = getEnvVarStringOrDefault("TRACKER_TABLE_NAME", fmt.Sprintf("%s-%s", "tracker-table", LocalEnv))
 }
 
 func getEnvVarStringOrDefault(envVar string, defaultValue string) string {

--- a/internal/handlers/event.go
+++ b/internal/handlers/event.go
@@ -25,7 +25,7 @@ const (
 type ReceiverEventRequest struct {
 	ReceiverID string            `json:"receiverId" validate:"required"`
 	UserID     string            `json:"userId" validate:"required"`
-	Type       string            `json:"type" validate:"required"`
+	TrackerID  string            `json:"trackerId" validate:"required"`
 	StartTime  string            `json:"startTime" validate:"required"`
 	EndTime    string            `json:"endTime" validate:"required"`
 	Data       []event.DataPoint `json:"data"`
@@ -72,6 +72,16 @@ func HandleReceiverEvent(ctx context.Context, params HandlerParams) (awsevents.A
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
+	t, err := params.TrackerRepo.GetTracker(rer.ReceiverID, rer.TrackerID)
+	if err != nil {
+		params.AppCfg.Logger.Error("error retrieving tracker for event", zap.String(log.ReceiverIDLogKey, rer.ReceiverID), zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if t == nil {
+		params.AppCfg.Logger.Error("tracker not found for event", zap.String(log.ReceiverIDLogKey, rer.ReceiverID))
+		return response.CreateBadRequestResponse(), nil
+	}
+
 	opts := []event.EntryOption{}
 	if len(rer.Data) > 0 {
 		opts = append(opts, event.WithData(rer.Data))
@@ -81,11 +91,7 @@ func HandleReceiverEvent(ctx context.Context, params HandlerParams) (awsevents.A
 		opts = append(opts, event.WithNote(rer.Note))
 	}
 
-	newEvent, err := event.NewEntry(rer.ReceiverID, u.UserID, rer.Type, rer.StartTime, rer.EndTime, opts...)
-	if err != nil {
-		params.AppCfg.Logger.Error("error creating new event entry", zap.Error(err))
-		return response.CreateBadRequestResponse(), nil
-	}
+	newEvent := event.NewTrackerEntry(rer.ReceiverID, u.UserID, rer.TrackerID, rer.StartTime, rer.EndTime, opts...)
 
 	err = params.EventRepo.AddEvent(newEvent)
 	if err != nil {

--- a/internal/handlers/event_test.go
+++ b/internal/handlers/event_test.go
@@ -24,8 +24,8 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestMethod: http.MethodPost,
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
-				"userID":     "User#123",
-				"type":       "Shower",
+				"userId":     "User#123",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
@@ -39,8 +39,8 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestMethod: http.MethodPost,
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
-				"userID":     "User#123",
-				"type":       "Shower",
+				"userId":     "User#123",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
@@ -54,8 +54,8 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestMethod: http.MethodPost,
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
-				"userID":     "User#123",
-				"type":       "Shower",
+				"userId":     "User#123",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 				"data": []event.DataPoint{
@@ -84,7 +84,7 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
 				"userId":     "User#Error",
-				"type":       "Shower",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
@@ -95,7 +95,7 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
 				"userId":     "User#RelationshipError",
-				"type":       "Shower",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
@@ -106,29 +106,40 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
 				"userId":     "User#NotACareGiver",
-				"type":       "Shower",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
 			expectedStatusCode: http.StatusForbidden,
 		},
-		"Sad Path - Bad Event Name": {
+		"Sad Path - Tracker Not Found": {
 			requestMethod: http.MethodPost,
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
 				"userId":     "User#123",
-				"type":       "badEventType",
+				"trackerId":  "Tracker#NotFound",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
 			expectedStatusCode: http.StatusBadRequest,
+		},
+		"Sad Path - Tracker Repo Error": {
+			requestMethod: http.MethodPost,
+			requestBody: map[string]interface{}{
+				"receiverId": "Receiver#123",
+				"userId":     "User#123",
+				"trackerId":  "Tracker#Error",
+				"startTime":  "2023-10-01T12:00:00Z",
+				"endTime":    "2024-10-01T12:00:00Z",
+			},
+			expectedStatusCode: http.StatusInternalServerError,
 		},
 		"Sad Path - Bad Event Data": {
 			requestMethod: http.MethodPost,
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
 				"userId":     "User#123",
-				"type":       "Weight",
+				"trackerId":  "Tracker#123",
 				"data":       "wrongDataType",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
@@ -140,7 +151,7 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#Error",
 				"userId":     "User#123",
-				"type":       "Weight",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2024-10-01T12:00:00Z",
 			},
@@ -150,8 +161,8 @@ func TestHandleReceiverEvent(t *testing.T) {
 			requestMethod: http.MethodPost,
 			requestBody: map[string]interface{}{
 				"receiverId": "Receiver#123",
-				"userID":     "User#123",
-				"type":       "Shower",
+				"userId":     "User#123",
+				"trackerId":  "Tracker#123",
 				"startTime":  "2023-10-01T12:00:00Z",
 				"endTime":    "2023-09-01T12:00:00Z",
 			},
@@ -174,6 +185,7 @@ func TestHandleReceiverEvent(t *testing.T) {
 				ReceiverRepo:     testReceiverRepo,
 				EventRepo:        testEventRepo,
 				RelationshipRepo: testRelationshipRepo,
+				TrackerRepo:      testTrackerRepo,
 			}
 			resp, err := HandleReceiverEvent(context.Background(), params)
 			assert.Nil(t, err)

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -29,6 +29,7 @@ type HandlerParams struct {
 	ReceiverRepo     repository.ReceiverRepositoryProvider
 	EventRepo        repository.EventRepositoryProvider
 	RelationshipRepo repository.RelationshipRepositoryProvider
+	TrackerRepo      repository.TrackerRepositoryProvider
 }
 
 type Endpoint struct {
@@ -51,6 +52,13 @@ var handlersMap = map[Endpoint]HandlerFunc{
 	{"/events/{receiverId}", http.MethodGet}:         HandleGetReceiverEvents,
 	{"/events/configs", http.MethodGet}:              HandleGetEventConfigs,
 	{"/feedback", http.MethodPost}:                   HandleFeedbackRequest,
+	{"/tracker", http.MethodPost}:                             HandleCreateTracker,
+	{"/trackers/{receiverId}", http.MethodGet}:               HandleListTrackers,
+	{"/tracker/{trackerId}", http.MethodGet}:                 HandleGetTracker,
+	{"/tracker/{trackerId}", http.MethodPut}:                 HandleUpdateTracker,
+	{"/tracker/{trackerId}", http.MethodDelete}:              HandleDeleteTracker,
+	{"/trackers/templates", http.MethodGet}:                  HandleListTrackerTemplates,
+	{"/trackers/templates/{templateName}", http.MethodGet}:   HandleGetTrackerTemplate,
 }
 
 type RegistryProvider interface {
@@ -64,15 +72,17 @@ type Registry struct {
 	ReceiverRepo     repository.ReceiverRepositoryProvider
 	EventRepo        repository.EventRepositoryProvider
 	RelationshipRepo repository.RelationshipRepositoryProvider
+	TrackerRepo      repository.TrackerRepositoryProvider
 }
 
-func NewRegistry(appCfg *appconfig.AppConfig, userRepo repository.UserRepositoryProvider, receiverRepo repository.ReceiverRepositoryProvider, eventRepo repository.EventRepositoryProvider, relationshipRepo repository.RelationshipRepositoryProvider) *Registry {
+func NewRegistry(appCfg *appconfig.AppConfig, userRepo repository.UserRepositoryProvider, receiverRepo repository.ReceiverRepositoryProvider, eventRepo repository.EventRepositoryProvider, relationshipRepo repository.RelationshipRepositoryProvider, trackerRepo repository.TrackerRepositoryProvider) *Registry {
 	return &Registry{
 		AppCfg:           appCfg,
 		UserRepo:         userRepo,
 		ReceiverRepo:     receiverRepo,
 		EventRepo:        eventRepo,
 		RelationshipRepo: relationshipRepo,
+		TrackerRepo:      trackerRepo,
 	}
 }
 
@@ -94,6 +104,7 @@ func (r *Registry) RunHandler(ctx context.Context, handler HandlerFunc, request 
 		ReceiverRepo:     r.ReceiverRepo,
 		EventRepo:        r.EventRepo,
 		RelationshipRepo: r.RelationshipRepo,
+		TrackerRepo:      r.TrackerRepo,
 	}
 
 	return handler(ctx, params)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -90,7 +90,7 @@ func TestGetRegisteredHandler(t *testing.T) {
 		},
 	}
 
-	testHandlerRegistry := NewRegistry(nil, nil, nil, nil, nil)
+	testHandlerRegistry := NewRegistry(nil, nil, nil, nil, nil, nil)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			handler, ok := testHandlerRegistry.GetHandler(tc.request)

--- a/internal/handlers/mock_test.go
+++ b/internal/handlers/mock_test.go
@@ -149,6 +149,20 @@ func (me *MockEventRepo) DeleteEvent(rid, eid string) error {
 	return errors.New("unsupported mock")
 }
 
+func (me *MockEventRepo) HasEventsForTracker(receiverID, trackerID string) (bool, error) {
+	switch trackerID {
+	case "Tracker#123":
+		return true, nil
+	case "Tracker#NoEvents":
+		return false, nil
+	case "Tracker#EventCheckError":
+		return false, errors.New("error checking events for tracker")
+	case "Tracker#NotFound":
+		return false, nil
+	}
+	return false, nil
+}
+
 type MockRelationshipRepo struct{}
 
 func (mr *MockRelationshipRepo) GetRelationshipsByUser(uid string) ([]relationship.Relationship, error) {
@@ -257,6 +271,32 @@ func (m *MockTrackerRepo) GetTracker(receiverID, trackerID string) (*pkgtracker.
 			CreatedAt:  "2026-01-01T00:00:00Z",
 			UpdatedAt:  "2026-01-01T00:00:00Z",
 		}, nil
+	case "Tracker#456":
+		return &pkgtracker.Tracker{
+			TrackerID:  "Tracker#456",
+			ReceiverID: receiverID,
+			Name:       "Shower",
+			Kind:       pkgtracker.KindEvent,
+			Fields:     []pkgtracker.TrackerField{},
+			Icon:       "assets/shower-icon.svg",
+			Color:      pkgtracker.ColorConfig{Primary: "#1E90FF", Secondary: "#D1E8FF"},
+			IsActive:   true,
+			CreatedAt:  "2026-01-01T00:00:00Z",
+			UpdatedAt:  "2026-01-01T00:00:00Z",
+		}, nil
+	case "Tracker#EventCheckError":
+		return &pkgtracker.Tracker{
+			TrackerID:  "Tracker#EventCheckError",
+			ReceiverID: receiverID,
+			Name:       "Walk",
+			Kind:       pkgtracker.KindEvent,
+			Fields:     []pkgtracker.TrackerField{},
+			Icon:       "assets/walk-icon.svg",
+			Color:      pkgtracker.ColorConfig{Primary: "#990000", Secondary: "#ff6666"},
+			IsActive:   true,
+			CreatedAt:  "2026-01-01T00:00:00Z",
+			UpdatedAt:  "2026-01-01T00:00:00Z",
+		}, nil
 	case "Tracker#NotFound":
 		return nil, nil
 	case "Tracker#Error":
@@ -300,7 +340,7 @@ func (m *MockTrackerRepo) UpdateTracker(t *pkgtracker.Tracker) error {
 
 func (m *MockTrackerRepo) DeleteTracker(receiverID, trackerID string) error {
 	switch trackerID {
-	case "Tracker#123":
+	case "Tracker#123", "Tracker#456":
 		return nil
 	case "Tracker#Error":
 		return errors.New("error deleting tracker")

--- a/internal/handlers/mock_test.go
+++ b/internal/handlers/mock_test.go
@@ -2,11 +2,14 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/care-giver-app/care-giver-golang-common/pkg/event"
 	"github.com/care-giver-app/care-giver-golang-common/pkg/receiver"
 	"github.com/care-giver-app/care-giver-golang-common/pkg/relationship"
 	"github.com/care-giver-app/care-giver-golang-common/pkg/repository"
+	pkgtracker "github.com/care-giver-app/care-giver-golang-common/pkg/tracker"
 	"github.com/care-giver-app/care-giver-golang-common/pkg/user"
 )
 
@@ -160,6 +163,12 @@ func (mr *MockRelationshipRepo) GetRelationshipsByUser(uid string) ([]relationsh
 			},
 			{
 				UserID:             "User#123",
+				ReceiverID:         "Receiver#Empty",
+				PrimaryCareGiver:   true,
+				EmailNotifications: false,
+			},
+			{
+				UserID:             "User#123",
 				ReceiverID:         "Receiver#Error",
 				PrimaryCareGiver:   false,
 				EmailNotifications: false,
@@ -214,6 +223,89 @@ func (mr *MockRelationshipRepo) GetRelationship(userID string, receiverID string
 
 func (mr *MockRelationshipRepo) GetRelationshipsByEmailNotifications() ([]relationship.Relationship, error) {
 	return nil, errors.New("unsupported mock")
+}
+
+var testTrackerRepo = &MockTrackerRepo{}
+
+type MockTrackerRepo struct{}
+
+func (m *MockTrackerRepo) CreateTracker(t *pkgtracker.Tracker) error {
+	switch t.ReceiverID {
+	case "Receiver#123":
+		if strings.EqualFold(t.Name, "Duplicate Name") {
+			return fmt.Errorf("name already in use for this receiver")
+		}
+		return nil
+	case "Receiver#Error":
+		return errors.New("error creating tracker")
+	}
+	return errors.New("unsupported mock")
+}
+
+func (m *MockTrackerRepo) GetTracker(receiverID, trackerID string) (*pkgtracker.Tracker, error) {
+	switch trackerID {
+	case "Tracker#123":
+		return &pkgtracker.Tracker{
+			TrackerID:  "Tracker#123",
+			ReceiverID: receiverID,
+			Name:       "Blood Pressure",
+			Kind:       pkgtracker.KindMeasurement,
+			Fields:     []pkgtracker.TrackerField{{Name: "systolic", InputType: "number", Required: true}},
+			Icon:       "assets/icon.svg",
+			Color:      pkgtracker.ColorConfig{Primary: "#000", Secondary: "#fff"},
+			IsActive:   true,
+			CreatedAt:  "2026-01-01T00:00:00Z",
+			UpdatedAt:  "2026-01-01T00:00:00Z",
+		}, nil
+	case "Tracker#NotFound":
+		return nil, nil
+	case "Tracker#Error":
+		return nil, errors.New("error getting tracker")
+	}
+	return nil, errors.New("unsupported mock")
+}
+
+func (m *MockTrackerRepo) ListTrackers(receiverID string) ([]pkgtracker.Tracker, error) {
+	switch receiverID {
+	case "Receiver#123":
+		return []pkgtracker.Tracker{
+			{
+				TrackerID:  "Tracker#123",
+				ReceiverID: "Receiver#123",
+				Name:       "Blood Pressure",
+				Kind:       pkgtracker.KindMeasurement,
+				Fields:     []pkgtracker.TrackerField{},
+				IsActive:   true,
+				CreatedAt:  "2026-01-01T00:00:00Z",
+				UpdatedAt:  "2026-01-01T00:00:00Z",
+			},
+		}, nil
+	case "Receiver#Empty":
+		return []pkgtracker.Tracker{}, nil
+	case "Receiver#Error":
+		return nil, errors.New("error listing trackers")
+	}
+	return nil, errors.New("unsupported mock")
+}
+
+func (m *MockTrackerRepo) UpdateTracker(t *pkgtracker.Tracker) error {
+	switch t.TrackerID {
+	case "Tracker#123":
+		return nil
+	case "Tracker#Error":
+		return errors.New("error updating tracker")
+	}
+	return errors.New("unsupported mock")
+}
+
+func (m *MockTrackerRepo) DeleteTracker(receiverID, trackerID string) error {
+	switch trackerID {
+	case "Tracker#123":
+		return nil
+	case "Tracker#Error":
+		return errors.New("error deleting tracker")
+	}
+	return errors.New("unsupported mock")
 }
 
 func (mr *MockRelationshipRepo) GetRelationshipsByReceiver(rid string) ([]relationship.Relationship, error) {

--- a/internal/handlers/tracker.go
+++ b/internal/handlers/tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/care-giver-app/care-giver-golang-common/pkg/receiver"
 	"github.com/care-giver-app/care-giver-golang-common/pkg/relationship"
 	pkgtracker "github.com/care-giver-app/care-giver-golang-common/pkg/tracker"
+	"github.com/care-giver-app/care-giver-golang-common/pkg/user"
 	"go.uber.org/zap"
 )
 
@@ -42,11 +43,6 @@ type UpdateTrackerRequest struct {
 	IsActive        *bool                      `json:"isActive,omitempty"`
 }
 
-func extractUID(params HandlerParams) (string, bool) {
-	uid, ok := params.Request.RequestContext.Authorizer["custom:db_user_id"].(string)
-	return uid, ok && uid != ""
-}
-
 func isCareGiver(params HandlerParams, uid, rid string) (bool, error) {
 	rels, err := params.RelationshipRepo.GetRelationshipsByUser(uid)
 	if err != nil {
@@ -58,13 +54,14 @@ func isCareGiver(params HandlerParams, uid, rid string) (bool, error) {
 func HandleCreateTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, createTracker)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
 	var req CreateTrackerRequest
-	if err := readRequestBody(params.Request.Body, &req); err != nil {
+	if err = readRequestBody(params.Request.Body, &req); err != nil {
 		params.AppCfg.Logger.Error(requestBodyError, zap.Error(err))
 		return response.CreateBadRequestResponse(), nil
 	}
@@ -105,8 +102,9 @@ func HandleCreateTracker(ctx context.Context, params HandlerParams) (awsevents.A
 func HandleListTrackers(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, listTrackers)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
@@ -143,8 +141,9 @@ func HandleListTrackers(ctx context.Context, params HandlerParams) (awsevents.AP
 func HandleGetTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getTracker)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
@@ -187,8 +186,9 @@ func HandleGetTracker(ctx context.Context, params HandlerParams) (awsevents.APIG
 func HandleUpdateTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, updateTracker)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
@@ -280,8 +280,9 @@ func HandleUpdateTracker(ctx context.Context, params HandlerParams) (awsevents.A
 func HandleDeleteTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, deleteTracker)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 

--- a/internal/handlers/tracker.go
+++ b/internal/handlers/tracker.go
@@ -317,6 +317,18 @@ func HandleDeleteTracker(ctx context.Context, params HandlerParams) (awsevents.A
 		return response.CreateResourceNotFoundResponse(), nil
 	}
 
+	hasEvents, err := params.EventRepo.HasEventsForTracker(rid, tid)
+	if err != nil {
+		params.AppCfg.Logger.Error("error checking events for tracker", zap.String(log.ReceiverIDLogKey, rid), zap.String("tracker_id", tid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if hasEvents {
+		return response.FormatResponse(
+			response.ErrorResponse{Status: "Conflict", DeveloperText: "This tracker has associated events. Deactivate it instead of deleting it."},
+			http.StatusConflict,
+		), nil
+	}
+
 	if err := params.TrackerRepo.DeleteTracker(rid, tid); err != nil {
 		params.AppCfg.Logger.Error("error deleting tracker", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
 		return response.CreateInternalServerErrorResponse(), nil

--- a/internal/handlers/tracker.go
+++ b/internal/handlers/tracker.go
@@ -1,0 +1,326 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	awsevents "github.com/aws/aws-lambda-go/events"
+	"github.com/care-giver-app/care-giver-api/internal/response"
+	"github.com/care-giver-app/care-giver-golang-common/pkg/log"
+	"github.com/care-giver-app/care-giver-golang-common/pkg/receiver"
+	"github.com/care-giver-app/care-giver-golang-common/pkg/relationship"
+	pkgtracker "github.com/care-giver-app/care-giver-golang-common/pkg/tracker"
+	"go.uber.org/zap"
+)
+
+const (
+	createTracker = "create tracker"
+	listTrackers  = "list trackers"
+	getTracker    = "get tracker"
+	updateTracker = "update tracker"
+	deleteTracker = "delete tracker"
+)
+
+type CreateTrackerRequest struct {
+	ReceiverID      string                    `json:"receiverId"        validate:"required"`
+	Name            string                    `json:"name"              validate:"required"`
+	Kind            pkgtracker.TrackerKind    `json:"kind"              validate:"required"`
+	Fields          []pkgtracker.TrackerField `json:"fields"`
+	AlertThresholds []pkgtracker.AlertThreshold `json:"alertThresholds,omitempty"`
+	Icon            string                    `json:"icon"              validate:"required"`
+	Color           pkgtracker.ColorConfig    `json:"color"`
+	IsActive        *bool                     `json:"isActive,omitempty"`
+}
+
+type UpdateTrackerRequest struct {
+	Name            *string                    `json:"name,omitempty"`
+	Fields          *[]pkgtracker.TrackerField  `json:"fields,omitempty"`
+	AlertThresholds *[]pkgtracker.AlertThreshold `json:"alertThresholds,omitempty"`
+	Icon            *string                    `json:"icon,omitempty"`
+	Color           *pkgtracker.ColorConfig    `json:"color,omitempty"`
+	IsActive        *bool                      `json:"isActive,omitempty"`
+}
+
+func extractUID(params HandlerParams) (string, bool) {
+	uid, ok := params.Request.RequestContext.Authorizer["custom:db_user_id"].(string)
+	return uid, ok && uid != ""
+}
+
+func isCareGiver(params HandlerParams, uid, rid string) (bool, error) {
+	rels, err := params.RelationshipRepo.GetRelationshipsByUser(uid)
+	if err != nil {
+		return false, err
+	}
+	return relationship.IsACareGiver(uid, rid, rels), nil
+}
+
+func HandleCreateTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, createTracker)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	var req CreateTrackerRequest
+	if err := readRequestBody(params.Request.Body, &req); err != nil {
+		params.AppCfg.Logger.Error(requestBodyError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	authorized, err := isCareGiver(params, uid, req.ReceiverID)
+	if err != nil {
+		params.AppCfg.Logger.Error(relationshipDatabaseError, zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if !authorized {
+		params.AppCfg.Logger.Error(userNotCareGiverError, zap.String(log.ReceiverIDLogKey, req.ReceiverID), zap.String(log.UserIDLogKey, uid))
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	isActive := true
+	if req.IsActive != nil {
+		isActive = *req.IsActive
+	}
+
+	t := pkgtracker.NewTracker(req.ReceiverID, req.Name, req.Kind, req.Fields, req.AlertThresholds, req.Icon, req.Color, isActive)
+	if err := t.Validate(); err != nil {
+		params.AppCfg.Logger.Error("tracker validation failed", zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	if err := params.TrackerRepo.CreateTracker(t); err != nil {
+		if strings.Contains(err.Error(), "name already in use") {
+			return response.FormatResponse(response.ErrorResponse{Status: "Conflict"}, http.StatusConflict), nil
+		}
+		params.AppCfg.Logger.Error("error creating tracker", zap.String(log.ReceiverIDLogKey, req.ReceiverID), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+
+	params.AppCfg.Logger.Info(handlerSuccessful, zap.String("action", createTracker), zap.String(log.UserIDLogKey, uid), zap.String(log.ReceiverIDLogKey, t.ReceiverID))
+	return response.FormatResponse(t, http.StatusOK), nil
+}
+
+func HandleListTrackers(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, listTrackers)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	rid, err := validatePathParameters(params.Request, receiver.ParamID, receiver.DBPrefix)
+	if err != nil {
+		params.AppCfg.Logger.Error(pathParametersError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	authorized, err := isCareGiver(params, uid, rid)
+	if err != nil {
+		params.AppCfg.Logger.Error(relationshipDatabaseError, zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if !authorized {
+		params.AppCfg.Logger.Error(userNotCareGiverError, zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	trackers, err := params.TrackerRepo.ListTrackers(rid)
+	if err != nil {
+		params.AppCfg.Logger.Error("error listing trackers", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+
+	if trackers == nil {
+		trackers = []pkgtracker.Tracker{}
+	}
+
+	params.AppCfg.Logger.Info(handlerSuccessful, zap.String("action", listTrackers), zap.String(log.UserIDLogKey, uid), zap.String(log.ReceiverIDLogKey, rid))
+	return response.FormatResponse(trackers, http.StatusOK), nil
+}
+
+func HandleGetTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, getTracker)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	tid, err := validatePathParameters(params.Request, pkgtracker.ParamID, pkgtracker.DBPrefix)
+	if err != nil {
+		params.AppCfg.Logger.Error(pathParametersError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	rid, err := validateQueryParameters(params.Request, receiver.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	// authz before existence check — prevents probing (FR-014)
+	authorized, err := isCareGiver(params, uid, rid)
+	if err != nil {
+		params.AppCfg.Logger.Error(relationshipDatabaseError, zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if !authorized {
+		params.AppCfg.Logger.Error(userNotCareGiverError, zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	t, err := params.TrackerRepo.GetTracker(rid, tid)
+	if err != nil {
+		params.AppCfg.Logger.Error("error getting tracker", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if t == nil {
+		return response.CreateResourceNotFoundResponse(), nil
+	}
+
+	params.AppCfg.Logger.Info(handlerSuccessful, zap.String("action", getTracker), zap.String(log.UserIDLogKey, uid), zap.String(log.ReceiverIDLogKey, rid))
+	return response.FormatResponse(t, http.StatusOK), nil
+}
+
+func HandleUpdateTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, updateTracker)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	tid, err := validatePathParameters(params.Request, pkgtracker.ParamID, pkgtracker.DBPrefix)
+	if err != nil {
+		params.AppCfg.Logger.Error(pathParametersError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	rid, err := validateQueryParameters(params.Request, receiver.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	authorized, err := isCareGiver(params, uid, rid)
+	if err != nil {
+		params.AppCfg.Logger.Error(relationshipDatabaseError, zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if !authorized {
+		params.AppCfg.Logger.Error(userNotCareGiverError, zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	var req UpdateTrackerRequest
+	if err := readRequestBody(params.Request.Body, &req); err != nil {
+		params.AppCfg.Logger.Error(requestBodyError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	existing, err := params.TrackerRepo.GetTracker(rid, tid)
+	if err != nil {
+		params.AppCfg.Logger.Error("error getting tracker for update", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if existing == nil {
+		return response.CreateResourceNotFoundResponse(), nil
+	}
+
+	// name uniqueness check when name is being changed
+	if req.Name != nil && !strings.EqualFold(*req.Name, existing.Name) {
+		all, err := params.TrackerRepo.ListTrackers(rid)
+		if err != nil {
+			params.AppCfg.Logger.Error("error listing trackers for name check", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+			return response.CreateInternalServerErrorResponse(), nil
+		}
+		newNameLower := strings.ToLower(*req.Name)
+		for _, tr := range all {
+			if tr.TrackerID != tid && strings.ToLower(tr.Name) == newNameLower {
+				return response.FormatResponse(response.ErrorResponse{Status: "Conflict"}, http.StatusConflict), nil
+			}
+		}
+	}
+
+	if req.Name != nil {
+		existing.Name = *req.Name
+	}
+	if req.Fields != nil {
+		existing.Fields = *req.Fields
+	}
+	if req.AlertThresholds != nil {
+		existing.AlertThresholds = *req.AlertThresholds
+	}
+	if req.Icon != nil {
+		existing.Icon = *req.Icon
+	}
+	if req.Color != nil {
+		existing.Color = *req.Color
+	}
+	if req.IsActive != nil {
+		existing.IsActive = *req.IsActive
+	}
+
+	if err := existing.Validate(); err != nil {
+		params.AppCfg.Logger.Error("tracker validation failed after update", zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	if err := params.TrackerRepo.UpdateTracker(existing); err != nil {
+		params.AppCfg.Logger.Error("error updating tracker", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+
+	params.AppCfg.Logger.Info(handlerSuccessful, zap.String("action", updateTracker), zap.String(log.UserIDLogKey, uid), zap.String(log.ReceiverIDLogKey, rid))
+	return response.FormatResponse(existing, http.StatusOK), nil
+}
+
+func HandleDeleteTracker(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, deleteTracker)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	tid, err := validatePathParameters(params.Request, pkgtracker.ParamID, pkgtracker.DBPrefix)
+	if err != nil {
+		params.AppCfg.Logger.Error(pathParametersError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	rid, err := validateQueryParameters(params.Request, receiver.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	authorized, err := isCareGiver(params, uid, rid)
+	if err != nil {
+		params.AppCfg.Logger.Error(relationshipDatabaseError, zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if !authorized {
+		params.AppCfg.Logger.Error(userNotCareGiverError, zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	existing, err := params.TrackerRepo.GetTracker(rid, tid)
+	if err != nil {
+		params.AppCfg.Logger.Error("error getting tracker for delete", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if existing == nil {
+		return response.CreateResourceNotFoundResponse(), nil
+	}
+
+	if err := params.TrackerRepo.DeleteTracker(rid, tid); err != nil {
+		params.AppCfg.Logger.Error("error deleting tracker", zap.String(log.ReceiverIDLogKey, rid), zap.String(log.UserIDLogKey, uid))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+
+	params.AppCfg.Logger.Info(handlerSuccessful, zap.String("action", deleteTracker), zap.String(log.UserIDLogKey, uid), zap.String(log.ReceiverIDLogKey, rid), zap.String("tracker_id", tid))
+	return response.FormatResponse(map[string]string{"status": response.Success}, http.StatusOK), nil
+}

--- a/internal/handlers/tracker_templates.go
+++ b/internal/handlers/tracker_templates.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	awsevents "github.com/aws/aws-lambda-go/events"
+	"github.com/care-giver-app/care-giver-api/internal/response"
+	"github.com/care-giver-app/care-giver-golang-common/pkg/tracker"
+	"go.uber.org/zap"
+)
+
+const (
+	listTrackerTemplates = "list tracker templates"
+	getTrackerTemplate   = "get tracker template"
+)
+
+func HandleListTrackerTemplates(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, listTrackerTemplates)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	templates, err := tracker.GetAllTemplates()
+	if err != nil {
+		params.AppCfg.Logger.Error("error loading tracker templates", zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, listTrackerTemplates)
+	_ = uid
+	return response.FormatResponse(templates, http.StatusOK), nil
+}
+
+func HandleGetTrackerTemplate(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
+	params.AppCfg.Logger.Sugar().Infof(handlerStart, getTrackerTemplate)
+
+	uid, ok := extractUID(params)
+	if !ok {
+		return response.CreateAccessDeniedResponse(), nil
+	}
+
+	rawName, found := params.Request.PathParameters["templateName"]
+	if !found || rawName == "" {
+		params.AppCfg.Logger.Error("missing templateName path parameter")
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	templateName, err := url.PathUnescape(rawName)
+	if err != nil {
+		params.AppCfg.Logger.Error("failed to decode templateName", zap.Error(err))
+		return response.CreateBadRequestResponse(), nil
+	}
+
+	tmpl, err := tracker.GetTemplateByName(templateName)
+	if err != nil {
+		params.AppCfg.Logger.Error("error loading tracker template", zap.Error(err))
+		return response.CreateInternalServerErrorResponse(), nil
+	}
+	if tmpl == nil {
+		return response.CreateResourceNotFoundResponse(), nil
+	}
+
+	params.AppCfg.Logger.Sugar().Infof(handlerSuccessful, getTrackerTemplate)
+	_ = uid
+	return response.FormatResponse(tmpl, http.StatusOK), nil
+}

--- a/internal/handlers/tracker_templates.go
+++ b/internal/handlers/tracker_templates.go
@@ -8,6 +8,7 @@ import (
 	awsevents "github.com/aws/aws-lambda-go/events"
 	"github.com/care-giver-app/care-giver-api/internal/response"
 	"github.com/care-giver-app/care-giver-golang-common/pkg/tracker"
+	"github.com/care-giver-app/care-giver-golang-common/pkg/user"
 	"go.uber.org/zap"
 )
 
@@ -19,8 +20,9 @@ const (
 func HandleListTrackerTemplates(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, listTrackerTemplates)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 
@@ -38,8 +40,9 @@ func HandleListTrackerTemplates(ctx context.Context, params HandlerParams) (awse
 func HandleGetTrackerTemplate(ctx context.Context, params HandlerParams) (awsevents.APIGatewayProxyResponse, error) {
 	params.AppCfg.Logger.Sugar().Infof(handlerStart, getTrackerTemplate)
 
-	uid, ok := extractUID(params)
-	if !ok {
+	uid, err := validateQueryParameters(params.Request, user.ParamID)
+	if err != nil {
+		params.AppCfg.Logger.Error(queryParamsError, zap.Error(err))
 		return response.CreateAccessDeniedResponse(), nil
 	}
 

--- a/internal/handlers/tracker_templates_test.go
+++ b/internal/handlers/tracker_templates_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/care-giver-app/care-giver-api/internal/appconfig"
+	"github.com/care-giver-app/care-giver-api/internal/response"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTemplateParams(req events.APIGatewayProxyRequest) HandlerParams {
+	return HandlerParams{
+		AppCfg:  appconfig.NewAppConfig(),
+		Request: req,
+	}
+}
+
+func TestHandleListTrackerTemplates(t *testing.T) {
+	tests := map[string]struct {
+		request          events.APIGatewayProxyRequest
+		expectedStatus   int
+		checkBody        bool
+		expectedMinCount int
+	}{
+		"Happy Path - Returns All 7 Templates": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedStatus:   http.StatusOK,
+			checkBody:        true,
+			expectedMinCount: 7,
+		},
+		"Sad Path - Missing JWT Claim": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTemplateParams(tc.request)
+			resp, err := HandleListTrackerTemplates(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
+
+			if tc.checkBody {
+				var body []interface{}
+				assert.Nil(t, json.Unmarshal([]byte(resp.Body), &body))
+				assert.GreaterOrEqual(t, len(body), tc.expectedMinCount)
+			}
+		})
+	}
+}
+
+func TestHandleGetTrackerTemplate(t *testing.T) {
+	tests := map[string]struct {
+		request          events.APIGatewayProxyRequest
+		expectedResponse events.APIGatewayProxyResponse
+		checkName        string
+	}{
+		"Happy Path - Weight Template Found": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"templateName": "Weight"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
+			checkName:        "Weight",
+		},
+		"Happy Path - URL Encoded Name": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"templateName": "Doctor%20Appointment"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
+			checkName:        "Doctor Appointment",
+		},
+		"Sad Path - Missing JWT Claim": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"templateName": "Weight"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Missing templateName": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Unknown Template Name": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"templateName": "NonExistentTemplate"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateResourceNotFoundResponse(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTemplateParams(tc.request)
+			resp, err := HandleGetTrackerTemplate(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResponse.StatusCode, resp.StatusCode)
+
+			if tc.checkName != "" && resp.StatusCode == http.StatusOK {
+				var body map[string]interface{}
+				assert.Nil(t, json.Unmarshal([]byte(resp.Body), &body))
+				assert.Equal(t, tc.checkName, body["name"])
+			}
+		})
+	}
+}

--- a/internal/handlers/tracker_templates_test.go
+++ b/internal/handlers/tracker_templates_test.go
@@ -28,21 +28,17 @@ func TestHandleListTrackerTemplates(t *testing.T) {
 	}{
 		"Happy Path - Returns All 7 Templates": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodGet,
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedStatus:   http.StatusOK,
 			checkBody:        true,
 			expectedMinCount: 7,
 		},
-		"Sad Path - Missing JWT Claim": {
+		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodGet,
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
+				HTTPMethod:            http.MethodGet,
+				QueryStringParameters: map[string]string{},
 			},
 			expectedStatus: http.StatusForbidden,
 		},
@@ -72,53 +68,43 @@ func TestHandleGetTrackerTemplate(t *testing.T) {
 	}{
 		"Happy Path - Weight Template Found": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"templateName": "Weight"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"templateName": "Weight"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
 			checkName:        "Weight",
 		},
 		"Happy Path - URL Encoded Name": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"templateName": "Doctor%20Appointment"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"templateName": "Doctor%20Appointment"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
 			checkName:        "Doctor Appointment",
 		},
-		"Sad Path - Missing JWT Claim": {
+		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"templateName": "Weight"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"templateName": "Weight"},
+				QueryStringParameters: map[string]string{},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
 		"Sad Path - Missing templateName": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
 		},
 		"Sad Path - Unknown Template Name": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"templateName": "NonExistentTemplate"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"templateName": "NonExistentTemplate"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateResourceNotFoundResponse(),
 		},

--- a/internal/handlers/tracker_test.go
+++ b/internal/handlers/tracker_test.go
@@ -1,0 +1,503 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/care-giver-app/care-giver-api/internal/appconfig"
+	"github.com/care-giver-app/care-giver-api/internal/response"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTrackerParams(req events.APIGatewayProxyRequest) HandlerParams {
+	return HandlerParams{
+		AppCfg:           appconfig.NewAppConfig(),
+		Request:          req,
+		UserRepo:         testUserRepo,
+		ReceiverRepo:     testReceiverRepo,
+		RelationshipRepo: testRelationshipRepo,
+		TrackerRepo:      testTrackerRepo,
+	}
+}
+
+func authedRequest(uid string) map[string]interface{} {
+	return map[string]interface{}{
+		"custom:db_user_id": uid,
+	}
+}
+
+func TestHandleCreateTracker(t *testing.T) {
+	validBody, _ := json.Marshal(map[string]interface{}{
+		"receiverId": "Receiver#123",
+		"name":       "Walk",
+		"kind":       "event",
+		"fields":     []interface{}{},
+		"icon":       "assets/icon.svg",
+		"color":      map[string]string{"primary": "#000", "secondary": "#fff"},
+	})
+
+	tests := map[string]struct {
+		request        events.APIGatewayProxyRequest
+		expectedStatus int
+	}{
+		"Happy Path - Tracker Created": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body:       string(validBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		"Sad Path - Missing JWT Claim": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body:       string(validBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		"Sad Path - Bad Body": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body:       `{"receiverId": false}`,
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		"Sad Path - Not A CareGiver": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body:       string(validBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#NotACareGiver"),
+				},
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		"Sad Path - Name Conflict": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body: func() string {
+					b, _ := json.Marshal(map[string]interface{}{
+						"receiverId": "Receiver#123",
+						"name":       "Duplicate Name",
+						"kind":       "event",
+						"fields":     []interface{}{},
+						"icon":       "assets/icon.svg",
+						"color":      map[string]string{"primary": "#000", "secondary": "#fff"},
+					})
+					return string(b)
+				}(),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		"Sad Path - Repo Error": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body: func() string {
+					b, _ := json.Marshal(map[string]interface{}{
+						"receiverId": "Receiver#Error",
+						"name":       "Some Tracker",
+						"kind":       "event",
+						"fields":     []interface{}{},
+						"icon":       "assets/icon.svg",
+						"color":      map[string]string{"primary": "#000", "secondary": "#fff"},
+					})
+					return string(b)
+				}(),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"Sad Path - Invalid Kind": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodPost,
+				Body: func() string {
+					b, _ := json.Marshal(map[string]interface{}{
+						"receiverId": "Receiver#123",
+						"name":       "Bad Tracker",
+						"kind":       "invalid_kind",
+						"fields":     []interface{}{},
+						"icon":       "assets/icon.svg",
+						"color":      map[string]string{"primary": "#000", "secondary": "#fff"},
+					})
+					return string(b)
+				}(),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTrackerParams(tc.request)
+			resp, err := HandleCreateTracker(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestHandleListTrackers(t *testing.T) {
+	tests := map[string]struct {
+		request          events.APIGatewayProxyRequest
+		expectedResponse events.APIGatewayProxyResponse
+	}{
+		"Happy Path - Trackers Listed": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				PathParameters: map[string]string{
+					"receiverId": "Receiver#123",
+				},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
+		},
+		"Happy Path - Empty List Returns Array": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod: http.MethodGet,
+				PathParameters: map[string]string{
+					"receiverId": "Receiver#Empty",
+				},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
+		},
+		"Sad Path - Missing JWT Claim": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Bad Path Parameter": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"wrongParam": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Not A CareGiver": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#NotACareGiver"),
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Repo Error": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"receiverId": "Receiver#Error"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateInternalServerErrorResponse(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTrackerParams(tc.request)
+			resp, err := HandleListTrackers(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResponse.StatusCode, resp.StatusCode)
+
+			if tc.expectedResponse.StatusCode == http.StatusOK {
+				var body interface{}
+				assert.Nil(t, json.Unmarshal([]byte(resp.Body), &body))
+				assert.IsType(t, []interface{}{}, body, "list response must be a JSON array")
+			}
+		})
+	}
+}
+
+func TestHandleGetTracker(t *testing.T) {
+	tests := map[string]struct {
+		request          events.APIGatewayProxyRequest
+		expectedResponse events.APIGatewayProxyResponse
+	}{
+		"Happy Path - Tracker Found": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:     http.MethodGet,
+				PathParameters: map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{
+					"receiverId": "Receiver#123",
+				},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
+		},
+		"Sad Path - Missing JWT Claim Returns 403 Not 404": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Not A CareGiver Returns 403 Not 404": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#NotACareGiver"),
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Tracker Not Found": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"trackerId": "Tracker#NotFound"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateResourceNotFoundResponse(),
+		},
+		"Sad Path - Bad Path Parameter": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"wrong": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Missing receiverId Query Param": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Repo Error": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"trackerId": "Tracker#Error"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateInternalServerErrorResponse(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTrackerParams(tc.request)
+			resp, err := HandleGetTracker(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResponse.StatusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestHandleUpdateTracker(t *testing.T) {
+	validUpdateBody, _ := json.Marshal(map[string]interface{}{
+		"name": "Updated Name",
+	})
+
+	tests := map[string]struct {
+		request          events.APIGatewayProxyRequest
+		expectedResponse events.APIGatewayProxyResponse
+	}{
+		"Happy Path - Tracker Updated": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodPut,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				Body:                  string(validUpdateBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
+		},
+		"Sad Path - Missing JWT Claim": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodPut,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				Body:                  string(validUpdateBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Tracker Not Found": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodPut,
+				PathParameters:        map[string]string{"trackerId": "Tracker#NotFound"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				Body:                  string(validUpdateBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateResourceNotFoundResponse(),
+		},
+		"Sad Path - Immutable Field kind In Body": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodPut,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				Body:                  `{"kind": "event"}`,
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Not A CareGiver": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodPut,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				Body:                  string(validUpdateBody),
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#NotACareGiver"),
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTrackerParams(tc.request)
+			resp, err := HandleUpdateTracker(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResponse.StatusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestHandleDeleteTracker(t *testing.T) {
+	tests := map[string]struct {
+		request          events.APIGatewayProxyRequest
+		expectedResponse events.APIGatewayProxyResponse
+	}{
+		"Happy Path - Tracker Deleted": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.FormatResponse(map[string]string{"status": response.Success}, http.StatusOK),
+		},
+		"Sad Path - Missing JWT Claim": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Not A CareGiver": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#NotACareGiver"),
+				},
+			},
+			expectedResponse: response.CreateAccessDeniedResponse(),
+		},
+		"Sad Path - Tracker Not Found": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#NotFound"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateResourceNotFoundResponse(),
+		},
+		"Sad Path - Missing receiverId Query Param": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Repo Delete Error": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#Error"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: authedRequest("User#123"),
+				},
+			},
+			expectedResponse: response.CreateInternalServerErrorResponse(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := makeTrackerParams(tc.request)
+			resp, err := HandleDeleteTracker(context.Background(), params)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResponse.StatusCode, resp.StatusCode)
+		})
+	}
+}

--- a/internal/handlers/tracker_test.go
+++ b/internal/handlers/tracker_test.go
@@ -23,10 +23,8 @@ func makeTrackerParams(req events.APIGatewayProxyRequest) HandlerParams {
 	}
 }
 
-func authedRequest(uid string) map[string]interface{} {
-	return map[string]interface{}{
-		"custom:db_user_id": uid,
-	}
+func userIDParam(uid string) map[string]string {
+	return map[string]string{"userId": uid}
 }
 
 func TestHandleCreateTracker(t *testing.T) {
@@ -45,41 +43,33 @@ func TestHandleCreateTracker(t *testing.T) {
 	}{
 		"Happy Path - Tracker Created": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodPost,
-				Body:       string(validBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodPost,
+				Body:                  string(validBody),
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedStatus: http.StatusOK,
 		},
-		"Sad Path - Missing JWT Claim": {
+		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodPost,
-				Body:       string(validBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
+				HTTPMethod:            http.MethodPost,
+				Body:                  string(validBody),
+				QueryStringParameters: map[string]string{},
 			},
 			expectedStatus: http.StatusForbidden,
 		},
 		"Sad Path - Bad Body": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodPost,
-				Body:       `{"receiverId": false}`,
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodPost,
+				Body:                  `{"receiverId": false}`,
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		"Sad Path - Not A CareGiver": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodPost,
-				Body:       string(validBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#NotACareGiver"),
-				},
+				HTTPMethod:            http.MethodPost,
+				Body:                  string(validBody),
+				QueryStringParameters: userIDParam("User#NotACareGiver"),
 			},
 			expectedStatus: http.StatusForbidden,
 		},
@@ -97,9 +87,7 @@ func TestHandleCreateTracker(t *testing.T) {
 					})
 					return string(b)
 				}(),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedStatus: http.StatusConflict,
 		},
@@ -117,9 +105,7 @@ func TestHandleCreateTracker(t *testing.T) {
 					})
 					return string(b)
 				}(),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedStatus: http.StatusInternalServerError,
 		},
@@ -137,9 +123,7 @@ func TestHandleCreateTracker(t *testing.T) {
 					})
 					return string(b)
 				}(),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
@@ -162,65 +146,49 @@ func TestHandleListTrackers(t *testing.T) {
 	}{
 		"Happy Path - Trackers Listed": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodGet,
-				PathParameters: map[string]string{
-					"receiverId": "Receiver#123",
-				},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
 		},
 		"Happy Path - Empty List Returns Array": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod: http.MethodGet,
-				PathParameters: map[string]string{
-					"receiverId": "Receiver#Empty",
-				},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"receiverId": "Receiver#Empty"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
 		},
-		"Sad Path - Missing JWT Claim": {
+		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: map[string]string{},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
 		"Sad Path - Bad Path Parameter": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"wrongParam": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"wrongParam": "Receiver#123"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
 		},
 		"Sad Path - Not A CareGiver": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#NotACareGiver"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: userIDParam("User#NotACareGiver"),
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
 		"Sad Path - Repo Error": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"receiverId": "Receiver#Error"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"receiverId": "Receiver#Error"},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateInternalServerErrorResponse(),
 		},
@@ -249,25 +217,17 @@ func TestHandleGetTracker(t *testing.T) {
 	}{
 		"Happy Path - Tracker Found": {
 			request: events.APIGatewayProxyRequest{
-				HTTPMethod:     http.MethodGet,
-				PathParameters: map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{
-					"receiverId": "Receiver#123",
-				},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				HTTPMethod:            http.MethodGet,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
 		},
-		"Sad Path - Missing JWT Claim Returns 403 Not 404": {
+		"Sad Path - Missing userId Query Param Returns 403 Not 404": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodGet,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
 				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
@@ -275,10 +235,7 @@ func TestHandleGetTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodGet,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#NotACareGiver"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#NotACareGiver"},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
@@ -286,10 +243,7 @@ func TestHandleGetTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodGet,
 				PathParameters:        map[string]string{"trackerId": "Tracker#NotFound"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.CreateResourceNotFoundResponse(),
 		},
@@ -297,10 +251,7 @@ func TestHandleGetTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodGet,
 				PathParameters:        map[string]string{"wrong": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
 		},
@@ -308,10 +259,7 @@ func TestHandleGetTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodGet,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
 		},
@@ -319,10 +267,7 @@ func TestHandleGetTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodGet,
 				PathParameters:        map[string]string{"trackerId": "Tracker#Error"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.CreateInternalServerErrorResponse(),
 		},
@@ -351,23 +296,17 @@ func TestHandleUpdateTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodPut,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 				Body:                  string(validUpdateBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
 			},
 			expectedResponse: events.APIGatewayProxyResponse{StatusCode: http.StatusOK},
 		},
-		"Sad Path - Missing JWT Claim": {
+		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodPut,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
 				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
 				Body:                  string(validUpdateBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
@@ -375,11 +314,8 @@ func TestHandleUpdateTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodPut,
 				PathParameters:        map[string]string{"trackerId": "Tracker#NotFound"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 				Body:                  string(validUpdateBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
 			},
 			expectedResponse: response.CreateResourceNotFoundResponse(),
 		},
@@ -387,11 +323,8 @@ func TestHandleUpdateTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodPut,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 				Body:                  `{"kind": "event"}`,
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
 		},
@@ -399,11 +332,8 @@ func TestHandleUpdateTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodPut,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#NotACareGiver"},
 				Body:                  string(validUpdateBody),
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#NotACareGiver"),
-				},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
@@ -428,21 +358,15 @@ func TestHandleDeleteTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.FormatResponse(map[string]string{"status": response.Success}, http.StatusOK),
 		},
-		"Sad Path - Missing JWT Claim": {
+		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
 				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: map[string]interface{}{},
-				},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
@@ -450,10 +374,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#NotACareGiver"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#NotACareGiver"},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
 		},
@@ -461,10 +382,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
 				PathParameters:        map[string]string{"trackerId": "Tracker#NotFound"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.CreateResourceNotFoundResponse(),
 		},
@@ -472,10 +390,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
 				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
-				QueryStringParameters: map[string]string{},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
 		},
@@ -483,10 +398,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
 				PathParameters:        map[string]string{"trackerId": "Tracker#Error"},
-				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
-				RequestContext: events.APIGatewayProxyRequestContext{
-					Authorizer: authedRequest("User#123"),
-				},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.CreateInternalServerErrorResponse(),
 		},

--- a/internal/handlers/tracker_test.go
+++ b/internal/handlers/tracker_test.go
@@ -20,6 +20,7 @@ func makeTrackerParams(req events.APIGatewayProxyRequest) HandlerParams {
 		ReceiverRepo:     testReceiverRepo,
 		RelationshipRepo: testRelationshipRepo,
 		TrackerRepo:      testTrackerRepo,
+		EventRepo:        testEventRepo,
 	}
 }
 
@@ -357,7 +358,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 		"Happy Path - Tracker Deleted": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
-				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				PathParameters:        map[string]string{"trackerId": "Tracker#456"},
 				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
 			},
 			expectedResponse: response.FormatResponse(map[string]string{"status": response.Success}, http.StatusOK),
@@ -365,7 +366,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 		"Sad Path - Missing userId Query Param": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
-				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				PathParameters:        map[string]string{"trackerId": "Tracker#456"},
 				QueryStringParameters: map[string]string{"receiverId": "Receiver#123"},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
@@ -373,7 +374,7 @@ func TestHandleDeleteTracker(t *testing.T) {
 		"Sad Path - Not A CareGiver": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
-				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				PathParameters:        map[string]string{"trackerId": "Tracker#456"},
 				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#NotACareGiver"},
 			},
 			expectedResponse: response.CreateAccessDeniedResponse(),
@@ -389,10 +390,29 @@ func TestHandleDeleteTracker(t *testing.T) {
 		"Sad Path - Missing receiverId Query Param": {
 			request: events.APIGatewayProxyRequest{
 				HTTPMethod:            http.MethodDelete,
-				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				PathParameters:        map[string]string{"trackerId": "Tracker#456"},
 				QueryStringParameters: userIDParam("User#123"),
 			},
 			expectedResponse: response.CreateBadRequestResponse(),
+		},
+		"Sad Path - Tracker Has Events": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#123"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
+			},
+			expectedResponse: response.FormatResponse(
+				response.ErrorResponse{Status: "Conflict", DeveloperText: "This tracker has associated events. Deactivate it instead of deleting it."},
+				http.StatusConflict,
+			),
+		},
+		"Sad Path - Event Check Error": {
+			request: events.APIGatewayProxyRequest{
+				HTTPMethod:            http.MethodDelete,
+				PathParameters:        map[string]string{"trackerId": "Tracker#EventCheckError"},
+				QueryStringParameters: map[string]string{"receiverId": "Receiver#123", "userId": "User#123"},
+			},
+			expectedResponse: response.CreateInternalServerErrorResponse(),
 		},
 		"Sad Path - Repo Delete Error": {
 			request: events.APIGatewayProxyRequest{

--- a/internal/handlers/user_test.go
+++ b/internal/handlers/user_test.go
@@ -298,6 +298,12 @@ func TestHandlerGetUserRelationships(t *testing.T) {
 					},
 					{
 						UserID:             "User#123",
+						ReceiverID:         "Receiver#Empty",
+						PrimaryCareGiver:   true,
+						EmailNotifications: false,
+					},
+					{
+						UserID:             "User#123",
 						ReceiverID:         "Receiver#Error",
 						PrimaryCareGiver:   false,
 						EmailNotifications: false,

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	receiverRepo     *repository.ReceiverRepository
 	eventRepo        *repository.EventRepository
 	relationshipRepo *repository.RelationshipRepository
+	trackerRepo      *repository.TrackerRepository
 	handlerRegistry  handlers.RegistryProvider
 )
 
@@ -55,8 +56,11 @@ func init() {
 	appCfg.Logger.Info("initializing relationship repository")
 	relationshipRepo = repository.NewRelationshipRepository(context.TODO(), appCfg.RelationshipTableName, dynamoClient, appCfg.Logger)
 
+	appCfg.Logger.Info("initializing tracker repository")
+	trackerRepo = repository.NewTrackerRepository(context.TODO(), appCfg.TrackerTableName, dynamoClient, appCfg.Logger)
+
 	appCfg.Logger.Info("initializing handler registry")
-	handlerRegistry = handlers.NewRegistry(appCfg, userRepo, receiverRepo, eventRepo, relationshipRepo)
+	handlerRegistry = handlers.NewRegistry(appCfg, userRepo, receiverRepo, eventRepo, relationshipRepo, trackerRepo)
 }
 
 func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {

--- a/template.yaml
+++ b/template.yaml
@@ -63,6 +63,7 @@ Resources:
           - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/event-table-${Env}/index/receiver-start-time
           - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/relationship-table-${Env}
           - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/relationship-table-${Env}/index/*
+          - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/tracker-table-${Env}
       Roles:
       - Ref: CareGiverAPIRole
     Metadata:
@@ -212,6 +213,57 @@ Resources:
             RestApiId: !Ref CareGiverAPI
             Path: /feedback
             Method: POST
+        CreateTracker:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /tracker
+            Method: POST
+        ListTrackers:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /trackers/{receiverId}
+            Method: GET
+        GetTracker:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /tracker/{trackerId}
+            Method: GET
+            RequestParameters:
+              - method.request.querystring.receiverId:
+                  Required: true
+        UpdateTracker:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /tracker/{trackerId}
+            Method: PUT
+            RequestParameters:
+              - method.request.querystring.receiverId:
+                  Required: true
+        DeleteTracker:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /tracker/{trackerId}
+            Method: DELETE
+            RequestParameters:
+              - method.request.querystring.receiverId:
+                  Required: true
+        ListTrackerTemplates:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /trackers/templates
+            Method: GET
+        GetTrackerTemplate:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CareGiverAPI
+            Path: /trackers/templates/{templateName}
+            Method: GET
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           ENV: !Ref Env
@@ -220,6 +272,23 @@ Resources:
           EVENT_TABLE_NAME: !Sub event-table-${Env}
           RELATIONSHIP_TABLE_NAME: !Sub relationship-table-${Env}
           FEEDBACK_QUEUE_URL: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/care-giver-notifications-${Env}
+          TRACKER_TABLE_NAME: !Sub tracker-table-${Env}
+
+  TrackerTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub tracker-table-${Env}
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: receiver_id
+          AttributeType: S
+        - AttributeName: tracker_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: receiver_id
+          KeyType: HASH
+        - AttributeName: tracker_id
+          KeyType: RANGE
 
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group


### PR DESCRIPTION
## Summary

### Tracker CRUD API (spec 002)
- **SAM template**: new \`TrackerTable\` DynamoDB resource (PK: \`receiver_id\`, SK: \`tracker_id\`, PAY_PER_REQUEST), 7 API Gateway events, \`TRACKER_TABLE_NAME\` env var, IAM policy updated
- **CRUD handlers** (\`tracker.go\`): \`CreateTracker\`, \`ListTrackers\`, \`GetTracker\`, \`UpdateTracker\`, \`DeleteTracker\` — userId read from query params (consistent with all other endpoints), \`IsACareGiver\` authz (403 returned before 404 to prevent existence probing), in-memory name-uniqueness check (case-insensitive, active + inactive), partial updates via pointer fields
- **Template handlers** (\`tracker_templates.go\`): \`ListTrackerTemplates\`, \`GetTrackerTemplate\` — no \`IsACareGiver\` check, URL-decoded path param, case-insensitive lookup against 7 built-in templates
- **go.mod**: \`care-giver-golang-common\` bumped to \`v0.8.0\`

### Events bridged to trackers (spec 004)
- \`ReceiverEventRequest.Type\` replaced with \`TrackerID\`; \`HandleCreateEvent\` validates the tracker exists before persisting the event
- \`HandleDeleteTracker\` gates hard-delete: returns \`409 Conflict\` when the tracker has associated events
- Depends on: \`HasEventsForTracker\` added to \`EventRepository\` in \`care-giver-golang-common v0.8.0\`

## Routes

| Method | Path | Handler |
|--------|------|---------|
| POST | \`/tracker\` | \`HandleCreateTracker\` |
| GET | \`/trackers/{receiverId}\` | \`HandleListTrackers\` |
| GET | \`/tracker/{trackerId}\` | \`HandleGetTracker\` |
| PUT | \`/tracker/{trackerId}\` | \`HandleUpdateTracker\` |
| DELETE | \`/tracker/{trackerId}\` | \`HandleDeleteTracker\` |
| GET | \`/trackers/templates\` | \`HandleListTrackerTemplates\` |
| GET | \`/trackers/templates/{templateName}\` | \`HandleGetTrackerTemplate\` |

## Test plan

- [x] \`handlers/tracker_test.go\` — success, 400 bad params, 403 missing userId, 403 not a caregiver, 404 not found, 409 name conflict, 409 has-events delete gate, 500 repo error
- [x] \`handlers/tracker_templates_test.go\` — list returns ≥7 items, get by name (exact + URL-encoded), 400, 404
- [x] \`handlers/event_test.go\` — updated for tracker-based event creation (TrackerID replaces Type)
- [ ] Run \`go test ./...\` — all packages pass
- [ ] Deploy to dev and smoke-test full tracker CRUD lifecycle, multi-tenant isolation, template catalog, and event creation/delete gate

## Notes

- \`GetTracker\` and \`ListTrackers\` return 403 (not 404) when the caller is not a caregiver for the receiver — prevents existence probing (SC-002)
- \`ListTrackers\` always returns a JSON array, never \`null\`
- userId is read from the \`userId\` query param (not a JWT claim) — Cognito Authorizer requires the access token, which does not carry \`custom:db_user_id\`; consistent with all other endpoints
- Depends on: [care-giver-golang-common#16](https://github.com/care-giver-app/care-giver-golang-common/pull/16) (merged + tagged \`v0.8.0\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)